### PR TITLE
Add support for converting Python unicode strings to QStrings

### DIFF
--- a/src/runner/pythonrunner.cpp
+++ b/src/runner/pythonrunner.cpp
@@ -108,7 +108,7 @@ struct QString_from_python_str
   }
 
   static void *convertible(PyObject *objPtr) {
-    return PyString_Check(objPtr) ? objPtr : nullptr;
+    return PyString_Check(objPtr) || PyUnicode_Check(objPtr) ? objPtr : nullptr;
   }
 
   static void construct(PyObject *objPtr, bpy::converter::rvalue_from_python_stage1_data *data) {


### PR DESCRIPTION
This makes it possible to call C++ functions from Python using values returned from C++ functions (as `QString`s get converted to Python `unicode` objects).

I've tested this and confirmed it does what it's supposed to.