### PR TITLE
Register some functions which Tannin created wrappers for, but omitte…

### DIFF
--- a/src/runner/pythonrunner.cpp
+++ b/src/runner/pythonrunner.cpp
@@ -831,6 +831,9 @@ BOOST_PYTHON_MODULE(mobase)
       .def("origin", bpy::pure_virtual(&MOBase::IPluginList::origin))
       .def("onRefreshed", bpy::pure_virtual(&MOBase::IPluginList::onRefreshed))
       .def("onPluginMoved", bpy::pure_virtual(&MOBase::IPluginList::onPluginMoved))
+      .def("pluginNames", bpy::pure_virtual(&MOBase::IPluginList::pluginNames))
+      .def("setState", bpy::pure_virtual(&MOBase::IPluginList::setState))
+      .def("setLoadOrder", bpy::pure_virtual(&MOBase::IPluginList::setLoadOrder))
       ;
 
   bpy::to_python_converter<IModList::ModStates, QFlags_to_int<IModList::ModState>>();


### PR DESCRIPTION
…d to make accessible from Python

In commit https://github.com/Modorganizer2/modorganizer-plugin_python/commit/9a310229e78c2ce7c01362cb26a50611c54519b9 Tannin added wrappers for several C++ functions so they could be used from Python, but seems to have accidentally missed a few when registering them. This registers some omitted functions with the relevant Python class.