### PR TITLE
Better QFlags support

### DIFF
--- a/src/runner/pythonrunner.cpp
+++ b/src/runner/pythonrunner.cpp
@@ -883,12 +883,16 @@ BOOST_PYTHON_MODULE(mobase)
       .value("PluginsTxt", MOBase::IPluginGame::LoadOrderMechanism::PluginsTxt)
       ;
 
+  // This doesn't actually do the conversion, but might be convenient for accessing the names for enum bits
   bpy::enum_<MOBase::IPluginGame::ProfileSetting>("ProfileSetting")
       .value("mods", MOBase::IPluginGame::MODS)
       .value("configuration", MOBase::IPluginGame::CONFIGURATION)
       .value("savegames", MOBase::IPluginGame::SAVEGAMES)
       .value("preferDefaults", MOBase::IPluginGame::PREFER_DEFAULTS)
       ;
+
+  py::to_python_converter<IPluginGame::ProfileSettings, QFlags_to_int<IPluginGame::ProfileSetting>>();
+  QFlags_from_python_obj<IPluginGame::ProfileSetting>();
 
   bpy::class_<IPluginGameWrapper, boost::noncopyable>("IPluginGame")
       .def("gameName", bpy::pure_virtual(&MOBase::IPluginGame::gameName))

--- a/src/runner/pythonrunner.cpp
+++ b/src/runner/pythonrunner.cpp
@@ -913,7 +913,7 @@ BOOST_PYTHON_MODULE(mobase)
       .def("setGameVariant", bpy::pure_virtual(&MOBase::IPluginGame::setGameVariant))
       .def("binaryName", bpy::pure_virtual(&MOBase::IPluginGame::binaryName))
       .def("gameShortName", bpy::pure_virtual(&MOBase::IPluginGame::gameShortName))
-        .def("gameNexusName", bpy::pure_virtual(&MOBase::IPluginGame::gameNexusName))
+      .def("gameNexusName", bpy::pure_virtual(&MOBase::IPluginGame::gameNexusName))
       .def("iniFiles", bpy::pure_virtual(&MOBase::IPluginGame::iniFiles))
       .def("DLCPlugins", bpy::pure_virtual(&MOBase::IPluginGame::DLCPlugins))
       .def("CCPlugins", bpy::pure_virtual(&MOBase::IPluginGame::CCPlugins))
@@ -1011,7 +1011,7 @@ bool PythonRunner::initPython(const QString &pythonPath)
 
 bool handled_exec_file(bpy::str filename, bpy::object globals = bpy::object(), bpy::object locals = bpy::object())
 {
-    return bpy::handle_exception(std::bind<bpy::object(&)(bpy::str, bpy::object, bpy::object)>(bpy::exec_file, filename, globals, locals));
+  return bpy::handle_exception(std::bind<bpy::object(&)(bpy::str, bpy::object, bpy::object)>(bpy::exec_file, filename, globals, locals));
 }
 
 


### PR DESCRIPTION
QFlags conversion only worked in one direction and there were places where functions returned or took QFlags but the necessary converters hadn't been registered. This fixes that.

This will hopefully be the last thing that should work and looks like it works if you skim read the code but actually doesn't work when you try and use it that I find. I also think that in an ideal world, this project would be autogenerated from the UIBase headers and a file with the non-trivial converters as a lot of this project is just lists of types and their methods.