### PR TITLE
Add support for free plugins which don't implement any specialised interface

### DIFF
--- a/src/runner/proxypluginwrappers.h
+++ b/src/runner/proxypluginwrappers.h
@@ -26,8 +26,11 @@ virtual bool isActive() const override; \
 virtual QList<MOBase::PluginSetting> settings() const override;
 
 
-class IPluginWrapper : public MOBase::IPlugin, public boost::python::wrapper<MOBase::IPlugin>
+// Even though the base interface is not a QObject, this has to be because we have no way to pass Mod Organizer a plugin that implements multiple interfaces.
+// QObject must be the first base class because moc assumes the first base class is a QObject
+class IPluginWrapper : public QObject, public MOBase::IPlugin, public boost::python::wrapper<MOBase::IPlugin>
 {
+  Q_OBJECT
   Q_INTERFACES(MOBase::IPlugin)
 
   COMMON_I_PLUGIN_WRAPPER_DECLARATIONS

--- a/src/runner/pythonrunner.cpp
+++ b/src/runner/pythonrunner.cpp
@@ -1320,6 +1320,8 @@ QList<QObject*> PythonRunner::instantiate(const QString &pluginName)
     TRY_PLUGIN_TYPE(IPluginModPage, pluginObj);
     TRY_PLUGIN_TYPE(IPluginPreview, pluginObj);
     TRY_PLUGIN_TYPE(IPluginTool, pluginObj);
+    if (interfaceList.isEmpty())
+      TRY_PLUGIN_TYPE(IPluginWrapper, pluginObj);
 
     return interfaceList;
   } catch (const bpy::error_already_set&) {


### PR DESCRIPTION
@LostDragonist tried to write a free plugin, and it didn't work. When I checked, I realised the commit where I'd implemented support for that had been lost in the ether, so now I've written it again.