### PR TITLE
Correctly use SIP to transfer ownership of objects from Python to C++

### DIFF
--- a/src/runner/proxypluginwrappers.cpp
+++ b/src/runner/proxypluginwrappers.cpp
@@ -381,12 +381,13 @@ QWidget *IPluginPreviewWrapper::genFilePreview(const QString &fileName, const QS
 {
   // This is complicated, so we can't use the basic implementation
   try {
+    GILock lock;
     boost::python::override implementation = this->get_override("genFilePreview");
     if (!implementation)
       throw MissingImplementation(this->className, "genFilePreview");
     boost::python::object pyVersion = implementation(fileName, maxSize);
     // We need responsibility for deleting the QWidget to be transferred to C++
-    sipAPI()->api_transfer_to(pyVersion.ptr(), 0);
+    sipAPI()->api_transfer_to(pyVersion.ptr(), Py_None);
     return boost::python::extract<QWidget *>(pyVersion)();
   } PYCATCH;
 }

--- a/src/runner/pythonrunner.cpp
+++ b/src/runner/pythonrunner.cpp
@@ -612,7 +612,7 @@ struct QClass_converters
   {
     // This would transfer responsibility for deconstructing the object to C++, but Boost assumes l-value converters (such as this) don't do that
     // Instead, this should be called within the wrappers for functions which return deletable pointers.
-    //sipAPI()->api_transfer_to(objPtr, 0);
+    //sipAPI()->api_transfer_to(objPtr, Py_None);
     if (PyObject_TypeCheck(objPtr, sipAPI()->api_simplewrapper_type)) {
       sipSimpleWrapper *wrapper;
       wrapper = reinterpret_cast<sipSimpleWrapper*>(objPtr);
@@ -695,7 +695,7 @@ struct QInterface_converters
 
     // This would transfer responsibility for deconstructing the object to C++, but Boost assumes l-value converters (such as this) don't do that
     // Instead, this should be called within the wrappers for functions which return deletable pointers.
-    //sipAPI()->api_transfer_to(objPtr, 0);
+    //sipAPI()->api_transfer_to(objPtr, Py_None);
 
     sipSimpleWrapper *wrapper = reinterpret_cast<sipSimpleWrapper*>(objPtr);
     return wrapper->data;


### PR DESCRIPTION
`Py_None` isn't equivalent to a `nullptr`, `NULL` or `0`, so when SIP checks for it, that's what it requires. With this change, custom `QWidget`s returned from Python have their Python parts persist until the C++ pointer is deleted and no longer, fixing an annoying issue I was having with an experimental plugin.