### PR TITLE
Message forwarding

### DIFF
--- a/src/runner/error.h
+++ b/src/runner/error.h
@@ -1,7 +1,26 @@
 #ifndef ERROR_H
 #define ERROR_H
+#include <QString>
+#include <sstream>
 
 // turn an error from the python interpreter into an exception
 void reportPythonError();
+
+struct ErrWrapper
+{
+  static ErrWrapper & instance();
+  
+  void write(const char * message);
+
+  void startRecordingExceptionMessage();
+
+  void stopRecordingExceptionMessage();
+
+  QString getLastExceptionMessage();
+
+  std::stringstream buffer;
+  bool recordingExceptionMessage;
+  std::stringstream lastException;
+};
 
 #endif // ERROR_H

--- a/src/runner/pythonrunner.cpp
+++ b/src/runner/pythonrunner.cpp
@@ -1372,7 +1372,8 @@ bool PythonRunner::initPython(const QString &pythonPath)
     mainNamespace["moprivate"] = bpy::import("moprivate");
     bpy::import("site");
     bpy::exec("sys.stdout = moprivate.PrintWrapper()\n"
-              "sys.stderr = moprivate.ErrWrapper()\n",
+              "sys.stderr = moprivate.ErrWrapper()\n"
+              "sys.excepthook = lambda x, y, z: sys.__excepthook__(x, y, z)",
                         mainNamespace);
 
     return true;


### PR DESCRIPTION
This PR:

* Allows Python plugins to log stuff with the normal `print(message)` function and similar by forwarding its stdout to `qDebug`.
* Allows Python plugins to log errors with the normal `print(message, sys.stderr)` function and similar by forwarding its stderr to `qCritical`.
* Logs detailed messages for uncaught exceptions by making PyQt think we're using a custom exception handler (as it uses its own buggy exception message logger that doesn't get the message when the default is in use).