### PR TITLE
Update python bindings for UI base change and new filetree implementation

### DIFF
--- a/src/runner/proxypluginwrappers.cpp
+++ b/src/runner/proxypluginwrappers.cpp
@@ -353,10 +353,13 @@ std::set<QString> IPluginInstallerCustomWrapper::supportedExtensions() const
   return basicWrapperFunctionImplementation<IPluginInstallerCustomWrapper, std::set<QString>>(this, "supportedExtensions");
 }
 
-IPluginInstaller::EInstallResult IPluginInstallerCustomWrapper::install(GuessedValue<QString> &modName, QString gameName, const QString &archiveName,
-                                                                        const QString &version, int modID)
+IPluginInstaller::EInstallResult IPluginInstallerCustomWrapper::install(
+  GuessedValue<QString> &modName, QString gameName, const QString &archiveName, const QString &version, int modID)
 {
-  return basicWrapperFunctionImplementation<IPluginInstallerCustomWrapper, IPluginInstaller::EInstallResult>(this, "install", modName, gameName, archiveName, version, modID);
+  // Note: This requires far more less trouble than the "Simple" installer version since 1) there is no tree 
+  // and 2) there version and modId cannot be modified:
+  return basicWrapperFunctionImplementation<IPluginInstallerCustomWrapper, IPluginInstaller::EInstallResult>(
+    this, "install", boost::ref(modName), gameName, archiveName, version, modID);
 }
 
 /// end IPluginInstallerCustom Wrapper

--- a/src/runner/proxypluginwrappers.cpp
+++ b/src/runner/proxypluginwrappers.cpp
@@ -310,7 +310,10 @@ IPluginInstaller::EInstallResult IPluginInstallerSimpleWrapper::install(
 {
   namespace bpy = boost::python;
 
-  using return_type = std::variant<IPluginInstaller::EInstallResult, std::shared_ptr<IFileTree>, std::tuple<std::shared_ptr<IFileTree>, QString, int>> ;
+  using return_type = std::variant<
+    IPluginInstaller::EInstallResult,
+    std::shared_ptr<IFileTree>, 
+    std::tuple<IPluginInstaller::EInstallResult, std::shared_ptr<IFileTree>, QString, int>> ;
   auto ret = basicWrapperFunctionImplementation<IPluginInstallerSimpleWrapper, return_type>(this, "install", boost::ref(modName), tree, version, nexusID);
 
   return std::visit([&](auto const& t) {
@@ -322,11 +325,11 @@ IPluginInstaller::EInstallResult IPluginInstallerSimpleWrapper::install(
       tree = t;
       return IPluginInstaller::RESULT_SUCCESS;
     }
-    else if constexpr (std::is_same_v<type, std::tuple<std::shared_ptr<IFileTree>, QString, int>>) {
-      tree = std::get<0>(t);
-      version = std::get<1>(t);
-      nexusID = std::get<2>(t);
-      return IPluginInstaller::RESULT_SUCCESS;
+    else if constexpr (std::is_same_v<type, std::tuple<IPluginInstaller::EInstallResult, std::shared_ptr<IFileTree>, QString, int>>) {
+      tree = std::get<1>(t);
+      version = std::get<2>(t);
+      nexusID = std::get<3>(t);
+      return std::get<0>(t);
     }
     else {
       static_assert("Type not handled in boost::apply_visitor.");

--- a/src/runner/proxypluginwrappers.cpp
+++ b/src/runner/proxypluginwrappers.cpp
@@ -331,9 +331,6 @@ IPluginInstaller::EInstallResult IPluginInstallerSimpleWrapper::install(
       nexusID = std::get<3>(t);
       return std::get<0>(t);
     }
-    else {
-      static_assert("Type not handled in boost::apply_visitor.");
-    }
   }, ret);
 }
 

--- a/src/runner/proxypluginwrappers.h
+++ b/src/runner/proxypluginwrappers.h
@@ -132,25 +132,47 @@ protected:
 };
 
 
+#define COMMON_I_PLUGIN_INSTALLER_WRAPPER_DECLARATIONS public: \
+using IPluginInstaller::parentWidget; \
+using IPluginInstaller::manager; \
+virtual unsigned int priority() const override; \
+virtual bool isManualInstaller() const override; \
+virtual bool isArchiveSupported(std::shared_ptr<const MOBase::IFileTree> tree) const override; 
+
+
+class IPluginInstallerSimpleWrapper : public MOBase::IPluginInstallerSimple, public boost::python::wrapper<MOBase::IPluginInstallerSimple>
+{
+  Q_OBJECT
+  Q_INTERFACES(MOBase::IPlugin MOBase::IPluginInstaller MOBase::IPluginInstallerSimple)
+
+  COMMON_I_PLUGIN_WRAPPER_DECLARATIONS
+  COMMON_I_PLUGIN_INSTALLER_WRAPPER_DECLARATIONS
+
+public:
+  static constexpr const char* className = "IPluginInstallerSimpleWrapper";
+  using boost::python::wrapper<MOBase::IPluginInstallerSimple>::get_override;
+
+  virtual EInstallResult install(MOBase::GuessedValue<QString>& modName, std::shared_ptr<MOBase::IFileTree>& tree,
+    QString& version, int& nexusID) override;
+};
+
 class IPluginInstallerCustomWrapper : public MOBase::IPluginInstallerCustom, public boost::python::wrapper<MOBase::IPluginInstallerCustom>
 {
   Q_OBJECT
   Q_INTERFACES(MOBase::IPlugin MOBase::IPluginInstaller MOBase::IPluginInstallerCustom)
 
   COMMON_I_PLUGIN_WRAPPER_DECLARATIONS
+
+  COMMON_I_PLUGIN_INSTALLER_WRAPPER_DECLARATIONS
+
 public:
   static constexpr const char* className = "IPluginInstallerCustomWrapper";
   using boost::python::wrapper<MOBase::IPluginInstallerCustom>::get_override;
 
-  virtual unsigned int priority() const;
-  virtual bool isManualInstaller() const;
-  virtual bool isArchiveSupported(const MOBase::DirectoryTree &tree) const;
-  virtual bool isArchiveSupported(const QString &archiveName) const;
-  virtual std::set<QString> supportedExtensions() const;
+  virtual bool isArchiveSupported(const QString &archiveName) const override;
+  virtual std::set<QString> supportedExtensions() const override;
   virtual EInstallResult install(MOBase::GuessedValue<QString> &modName, QString gameName, const QString &archiveName,
-                                 const QString &version, int modID);
-  virtual void setParentWidget(QWidget *parent);
-
+                                 const QString &version, int modID) override;
 };
 
 

--- a/src/runner/pythonrunner.cpp
+++ b/src/runner/pythonrunner.cpp
@@ -1036,9 +1036,6 @@ BOOST_PYTHON_MODULE(mobase)
             else if constexpr (std::is_same_v<decltype(v), bool>) {
               return v;
             }
-            else {
-              static_assert("Incorrect visitor.");
-            }
           }, ret);
         });
       })

--- a/src/runner/pythonrunner.cpp
+++ b/src/runner/pythonrunner.cpp
@@ -1117,12 +1117,12 @@ BOOST_PYTHON_MODULE(mobase)
       ;
 
   bpy::enum_<MOBase::EGuessQuality>("GuessQuality")
-      .value("invalid", MOBase::GUESS_INVALID)
-      .value("fallback", MOBase::GUESS_FALLBACK)
-      .value("good", MOBase::GUESS_GOOD)
-      .value("meta", MOBase::GUESS_META)
-      .value("preset", MOBase::GUESS_PRESET)
-      .value("user", MOBase::GUESS_USER)
+      .value("INVALID", MOBase::GUESS_INVALID)
+      .value("FALLBACK", MOBase::GUESS_FALLBACK)
+      .value("GOOD", MOBase::GUESS_GOOD)
+      .value("META", MOBase::GUESS_META)
+      .value("PRESET", MOBase::GUESS_PRESET)
+      .value("USER", MOBase::GUESS_USER)
       ;
 
   bpy::class_<MOBase::GuessedValue<QString>, boost::noncopyable>("GuessedString", bpy::no_init)
@@ -1132,6 +1132,14 @@ BOOST_PYTHON_MODULE(mobase)
       .def("update",
            static_cast<GuessedValue<QString>& (GuessedValue<QString>::*)(const QString&, EGuessQuality)>(&GuessedValue<QString>::update),
            bpy::return_self<>())
+
+      // Methods to simulate the assignment operator:
+      .def("reset", +[](GuessedValue<QString>* gv) { *gv = GuessedValue<QString>(); }, bpy::return_self<>())
+      .def("reset", +[](GuessedValue<QString>* gv, const QString& value, EGuessQuality eq) { *gv = GuessedValue<QString>(value, eq); }, bpy::return_self<>())
+
+      // Use an intermediate lambda to avoid having to register the std::function conversion:
+      .def("setFilter", +[](GuessedValue<QString>* gv, bpy::object fn) { gv->setFilter(fn); })
+
       .def("variants", &MOBase::GuessedValue<QString>::variants, bpy::return_value_policy<bpy::copy_const_reference>())
       .def("__str__", &MOBase::GuessedValue<QString>::operator const QString&, bpy::return_value_policy<bpy::copy_const_reference>())
       ;
@@ -1285,11 +1293,11 @@ BOOST_PYTHON_MODULE(mobase)
   bpy::register_tuple<boost::tuple<std::shared_ptr<IFileTree>, QString, int>>();
   register_implicit_variant<IPluginInstaller::EInstallResult, std::shared_ptr<IFileTree>, boost::tuple<std::shared_ptr<IFileTree>, QString, int>>();
   bpy::enum_<MOBase::IPluginInstaller::EInstallResult>("InstallResult")
-      .value("success", MOBase::IPluginInstaller::RESULT_SUCCESS)
-      .value("failed", MOBase::IPluginInstaller::RESULT_FAILED)
-      .value("canceled", MOBase::IPluginInstaller::RESULT_CANCELED)
-      .value("manualRequested", MOBase::IPluginInstaller::RESULT_MANUALREQUESTED)
-      .value("notAttempted", MOBase::IPluginInstaller::RESULT_NOTATTEMPTED)
+      .value("SUCCESS", MOBase::IPluginInstaller::RESULT_SUCCESS)
+      .value("FAILED", MOBase::IPluginInstaller::RESULT_FAILED)
+      .value("CANCELED", MOBase::IPluginInstaller::RESULT_CANCELED)
+      .value("MANUAL_REQUESTED", MOBase::IPluginInstaller::RESULT_MANUALREQUESTED)
+      .value("NOT_ATTEMPTED", MOBase::IPluginInstaller::RESULT_NOTATTEMPTED)
       ;
 
   bpy::class_<IPluginInstallerSimpleWrapper, boost::noncopyable>("IPluginInstallerSimple")

--- a/src/runner/pythonrunner.cpp
+++ b/src/runner/pythonrunner.cpp
@@ -1302,16 +1302,16 @@ BOOST_PYTHON_MODULE(mobase)
 
   bpy::class_<IPluginInstallerSimpleWrapper, boost::noncopyable>("IPluginInstallerSimple")
     .def("install", &IPluginInstallerSimple::install)
-    .def("getParentWidget", &IPluginInstallerSimpleWrapper::parentWidget, bpy::return_value_policy<bpy::reference_existing_object>())
-    .def("getManager", &IPluginInstallerSimpleWrapper::manager, bpy::return_value_policy<bpy::reference_existing_object>())
+    .def("parentWidget", &IPluginInstallerSimpleWrapper::parentWidget, bpy::return_value_policy<bpy::reference_existing_object>())
+    .def("manager", &IPluginInstallerSimpleWrapper::manager, bpy::return_value_policy<bpy::reference_existing_object>())
     ;
 
   bpy::class_<IPluginInstallerCustomWrapper, boost::noncopyable>("IPluginInstallerCustom")
       .def("isArchiveSupported", &IPluginInstallerCustom::isArchiveSupported)
       .def("supportedExtensions", &IPluginInstallerCustom::supportedExtensions)
       .def("install", &IPluginInstallerCustom::install)
-      .def("getParentWidget", &IPluginInstallerCustomWrapper::parentWidget, bpy::return_value_policy<bpy::reference_existing_object>())
-      .def("getManager", &IPluginInstallerCustomWrapper::manager, bpy::return_value_policy<bpy::reference_existing_object>())
+      .def("parentWidget", &IPluginInstallerCustomWrapper::parentWidget, bpy::return_value_policy<bpy::reference_existing_object>())
+      .def("manager", &IPluginInstallerCustomWrapper::manager, bpy::return_value_policy<bpy::reference_existing_object>())
       ;
 
   bpy::class_<IPluginModPageWrapper, boost::noncopyable>("IPluginModPage")

--- a/src/runner/pythonrunner.cpp
+++ b/src/runner/pythonrunner.cpp
@@ -995,7 +995,7 @@ BOOST_PYTHON_MODULE(mobase)
       .def("addCategory", bpy::pure_virtual(&IModInterface::addCategory))
       .def("removeCategory", bpy::pure_virtual(&IModInterface::removeCategory))
       .def("categories", bpy::pure_virtual(&IModInterface::categories))
-      .def("setGamePlugin", bpy::pure_virtual(&IModInterface::setGamePlugin))
+      .def("setGameName", bpy::pure_virtual(&IModInterface::setGameName))
       .def("setName", bpy::pure_virtual(&IModInterface::setName))
       .def("remove", bpy::pure_virtual(&IModInterface::remove))
       ;

--- a/src/runner/pythonrunner.cpp
+++ b/src/runner/pythonrunner.cpp
@@ -366,35 +366,6 @@ struct std_vector_to_python_list
 
 
 template <typename T>
-struct std_vector_from_python_obj
-{
-  std_vector_from_python_obj() {
-    bpy::converter::registry::push_back(
-      &convertible,
-      &construct,
-      bpy::type_id<std::vector<T> >());
-  }
-
-  static void* convertible(PyObject *objPtr) {
-    if (PyList_Check(objPtr)) return objPtr;
-    return nullptr;
-  }
-
-  static void construct(PyObject *objPtr, bpy::converter::rvalue_from_python_stage1_data *data) {
-    void *storage = ((bpy::converter::rvalue_from_python_storage<std::vector<T> >*)data)->storage.bytes;
-    std::vector<T> *result = new (storage) std::vector<T>();
-    bpy::list source(bpy::handle<>(bpy::borrowed(objPtr)));
-    int length = bpy::len(source);
-    for (int i = 0; i < length; ++i) {
-      result->push_back(bpy::extract<T>(source[i]));
-    }
-
-    data->convertible = storage;
-  }
-};
-
-
-template <typename T>
 struct QFlags_from_python_obj
 {
   QFlags_from_python_obj() {
@@ -413,36 +384,6 @@ struct QFlags_from_python_obj
     T tVersion = (T)intVersion;
     void *storage = ((bpy::converter::rvalue_from_python_storage<QFlags<T>> *)data)->storage.bytes;
     new (storage) QFlags<T>(tVersion);
-
-    data->convertible = storage;
-  }
-};
-
-
-template <typename T>
-struct stdset_from_python_list
-{
-  stdset_from_python_list() {
-    bpy::converter::registry::push_back(
-      &convertible,
-      &construct,
-      bpy::type_id<std::set<T> >());
-  }
-
-  static void* convertible(PyObject *objPtr) {
-    if (PyList_Check(objPtr)) return objPtr;
-    return nullptr;
-  }
-
-  static void construct(PyObject *objPtr, bpy::converter::rvalue_from_python_stage1_data *data) {
-    void *storage = ((bpy::converter::rvalue_from_python_storage<std::set<T> >*)data)->storage.bytes;
-    std::set<T> *result = new (storage) std::set<T>();
-
-    bpy::list source(bpy::handle<>(bpy::borrowed(objPtr)));
-    int length = bpy::len(source);
-    for (int i = 0; i < length; ++i) {
-      result->insert(bpy::extract<T>(source[i]));
-    }
 
     data->convertible = storage;
   }
@@ -985,7 +926,7 @@ BOOST_PYTHON_MODULE(mobase)
       ;
   }
 
-  utils::register_map<IFileTree::OverwritesType>();
+  utils::register_associative_container<IFileTree::OverwritesType>();
   bpy::register_variant<boost::variant<IFileTree::OverwritesType, std::size_t, bool>>();
 
   // IFileTree scope:
@@ -1393,12 +1334,9 @@ BOOST_PYTHON_MODULE(mobase)
   QMap_converters<QString, QVariant>();
   QMap_converters<QString, QStringList>();
 
-  std_vector_from_python_obj<unsigned int>();
-  std_vector_from_python_obj<Mapping>();
-  bpy::to_python_converter<std::vector<Mapping>,
-      std_vector_to_python_list<Mapping>>();
-
-  stdset_from_python_list<QString>();
+  utils::register_sequence_container<std::vector<unsigned int>>();
+  utils::register_sequence_container<std::vector<Mapping>>();
+  utils::register_set_container<std::set<QString>>();
 
   registerGameFeaturesPythonConverters();
 }

--- a/src/runner/pythonrunner.cpp
+++ b/src/runner/pythonrunner.cpp
@@ -1302,7 +1302,7 @@ BOOST_PYTHON_MODULE(mobase)
 
   bpy::class_<IPluginInstallerSimpleWrapper, boost::noncopyable>("IPluginInstallerSimple")
     .def("install", &IPluginInstallerSimple::install)
-    .def("parentWidget", &IPluginInstallerSimpleWrapper::parentWidget, bpy::return_value_policy<bpy::reference_existing_object>())
+    .def("parentWidget", &IPluginInstallerSimpleWrapper::parentWidget, bpy::return_value_policy<bpy::return_by_value>())
     .def("manager", &IPluginInstallerSimpleWrapper::manager, bpy::return_value_policy<bpy::reference_existing_object>())
     ;
 
@@ -1310,7 +1310,7 @@ BOOST_PYTHON_MODULE(mobase)
       .def("isArchiveSupported", &IPluginInstallerCustom::isArchiveSupported)
       .def("supportedExtensions", &IPluginInstallerCustom::supportedExtensions)
       .def("install", &IPluginInstallerCustom::install)
-      .def("parentWidget", &IPluginInstallerCustomWrapper::parentWidget, bpy::return_value_policy<bpy::reference_existing_object>())
+      .def("parentWidget", &IPluginInstallerSimpleWrapper::parentWidget, bpy::return_value_policy<bpy::return_by_value>())
       .def("manager", &IPluginInstallerCustomWrapper::manager, bpy::return_value_policy<bpy::reference_existing_object>())
       ;
 

--- a/src/runner/pythonrunner.cpp
+++ b/src/runner/pythonrunner.cpp
@@ -897,16 +897,6 @@ BOOST_PYTHON_MODULE(mobase)
       .def("__len__", &IFileTree::size)
       .def("__bool__", +[](const IFileTree* tree) { return !tree->empty(); })
       .def("__repr__", +[](const IFileTree* entry) { return "IFileTree(\"" + entry->name() + "\")"; })
-
-      .def("makeTree", +[]() -> std::shared_ptr<IFileTree> {
-          struct MyTree : public IFileTree {
-            MyTree(std::shared_ptr<IFileTree> parent = nullptr, QString name = "") : FileTreeEntry(parent, name), IFileTree() { }
-          protected:
-            std::shared_ptr<IFileTree> makeDirectory(std::shared_ptr<IFileTree> p, QString n) const override { return std::make_shared<MyTree>(p, n); }
-            void doPopulate(std::shared_ptr<IFileTree>, std::vector<std::shared_ptr<FileTreeEntry>> &) const override { }
-          };
-          return std::make_shared<MyTree>();
-      }).staticmethod("makeTree")
       ;
   }
   

--- a/src/runner/pythonrunner.cpp
+++ b/src/runner/pythonrunner.cpp
@@ -945,15 +945,15 @@ BOOST_PYTHON_MODULE(mobase)
 
       .def("isFile", &FileTreeEntry::isFile)
       .def("isDir", &FileTreeEntry::isDir)
-      .def("getFileType", &FileTreeEntry::fileType)
+      .def("fileType", &FileTreeEntry::fileType)
       // This should probably not be exposed in python since we provide automatic downcast:
       // .def("getTree", static_cast<std::shared_ptr<IFileTree>(FileTreeEntry::*)()>(&FileTreeEntry::astree))
-      .def("getName", &FileTreeEntry::name)
-      .def("getSuffix", &FileTreeEntry::suffix)
-      .def("getTime", &FileTreeEntry::time)
-      .def("getParent", static_cast<std::shared_ptr<IFileTree>(FileTreeEntry::*)()>(&FileTreeEntry::parent))
-      .def("getPath", &FileTreeEntry::path, bpy::arg("sep") = "\\")
-      .def("getPathFrom", &FileTreeEntry::pathFrom, bpy::arg("sep") = "\\")
+      .def("name", &FileTreeEntry::name)
+      .def("suffix", &FileTreeEntry::suffix)
+      .def("time", &FileTreeEntry::time)
+      .def("parent", static_cast<std::shared_ptr<IFileTree>(FileTreeEntry::*)()>(&FileTreeEntry::parent))
+      .def("path", &FileTreeEntry::path, bpy::arg("sep") = "\\")
+      .def("pathFrom", &FileTreeEntry::pathFrom, bpy::arg("sep") = "\\")
 
       // Mutable operation:
       .def("setTime", &FileTreeEntry::setTime)
@@ -986,7 +986,7 @@ BOOST_PYTHON_MODULE(mobase)
       .def("exists", static_cast<bool(IFileTree::*)(QString, IFileTree::FileTypes) const>(&IFileTree::exists), (bpy::arg("type") = IFileTree::FILE_OR_DIRECTORY))
       .def("find", static_cast<std::shared_ptr<FileTreeEntry>(IFileTree::*)(QString, IFileTree::FileTypes)>(&IFileTree::find), 
         bpy::arg("type") = IFileTree::FILE_OR_DIRECTORY, bpy::return_value_policy<DowncastReturn<FileTreeEntry, IFileTree>>())
-      .def("getPathTo", &IFileTree::pathTo, bpy::arg("sep") = "\\")
+      .def("pathTo", &IFileTree::pathTo, bpy::arg("sep") = "\\")
 
       // Kind-of-static operations:
       .def("createOrphanTree", &IFileTree::createOrphanTree, bpy::arg("name") = "")

--- a/src/runner/pythonrunner.cpp
+++ b/src/runner/pythonrunner.cpp
@@ -772,10 +772,16 @@ template <class FromType, class ToType>
 struct DowncastReturn {
 
   template <class T>
-  struct apply {
-    static_assert(std::is_convertible_v<T, std::shared_ptr<FromType>>);
+  struct apply_;
+  
+  template <class T>
+  struct apply_<std::shared_ptr<T>> {
+    static_assert(std::is_convertible_v<std::shared_ptr<T>, std::shared_ptr<FromType>>);
     using type = DowncastConverter<FromType, ToType>;
   };
+
+  template <class T>
+  using apply = apply_<std::decay_t<T>>;
 
 };
 
@@ -927,7 +933,7 @@ BOOST_PYTHON_MODULE(mobase)
   Functor_converter<bool(std::shared_ptr<FileTreeEntry> const&)>();
 
   // FileTreeEntry Scope:
-  auto fileTreeEntryClass = bpy::class_<FileTreeEntry, std::shared_ptr<FileTreeEntry>, boost::noncopyable>("FileTreeEntry", bpy::no_init);
+  auto fileTreeEntryClass = bpy::class_<FileTreeEntry, boost::noncopyable>("FileTreeEntry", bpy::no_init);
   {
     
     bpy::scope scope = fileTreeEntryClass;

--- a/src/runner/pythonrunner.cpp
+++ b/src/runner/pythonrunner.cpp
@@ -622,7 +622,7 @@ struct QClass_converters
       wrapper = reinterpret_cast<sipWrapper*>(objPtr);
       return wrapper->super.data;
     } else {
-      if (std::is_same_v<T, QStringList>)
+      if constexpr (std::is_same_v<T, QStringList>)
       {
         // QStringLists aren't wrapped by PyQt - regular Python string/unicode lists are used instead
         bpy::extract<QList<QString>> extractor(objPtr);
@@ -994,7 +994,7 @@ BOOST_PYTHON_MODULE(mobase)
       .def("addCategory", bpy::pure_virtual(&IModInterface::addCategory))
       .def("removeCategory", bpy::pure_virtual(&IModInterface::removeCategory))
       .def("categories", bpy::pure_virtual(&IModInterface::categories))
-      .def("setGameName", bpy::pure_virtual(&IModInterface::setGameName))
+      .def("setGamePlugin", bpy::pure_virtual(&IModInterface::setGamePlugin))
       .def("setName", bpy::pure_virtual(&IModInterface::setName))
       .def("remove", bpy::pure_virtual(&IModInterface::remove))
       ;

--- a/src/runner/pythonrunner.cpp
+++ b/src/runner/pythonrunner.cpp
@@ -883,6 +883,12 @@ BOOST_PYTHON_MODULE(mobase)
   Functor_converter<bool(const QString&)>();
   Functor_converter<void(const QString&, unsigned int)>();
 
+  bpy::class_<IOrganizer::FileInfo>("FileInfo", bpy::init<>())
+    .def_readwrite("filePath", &IOrganizer::FileInfo::filePath)
+    .def_readwrite("archive", &IOrganizer::FileInfo::archive)
+    .def_readwrite("origins", &IOrganizer::FileInfo::origins)
+    ;
+
   bpy::class_<IOrganizerWrapper, boost::noncopyable>("IOrganizer")
       .def("createNexusBridge", bpy::pure_virtual(&IOrganizer::createNexusBridge), bpy::return_value_policy<bpy::reference_existing_object>())
       .def("profileName", bpy::pure_virtual(&IOrganizer::profileName))

--- a/src/runner/pythonrunner.cpp
+++ b/src/runner/pythonrunner.cpp
@@ -938,9 +938,8 @@ BOOST_PYTHON_MODULE(mobase)
   {
     
     bpy::scope scope = fileTreeEntryClass;
-
     
-    bpy::enum_<FileTreeEntry::FileTypes>("FileType")
+    bpy::enum_<FileTreeEntry::FileTypes>("FileTypes")
     .value("FILE_OR_DIRECTORY", FileTreeEntry::FILE_OR_DIRECTORY)
     .value("FILE", FileTreeEntry::FILE)
     .value("DIRECTORY", FileTreeEntry::DIRECTORY)
@@ -951,7 +950,8 @@ BOOST_PYTHON_MODULE(mobase)
 
       .def("isFile", &FileTreeEntry::isFile)
       .def("isDir", &FileTreeEntry::isDir)
-      .def("fileType", &FileTreeEntry::fileType)
+      // Forcing the conversion to FileTypeS to avoid having to expose FileType in python:
+      .def("fileType", +[](FileTreeEntry* p) { return FileTreeEntry::FileTypes{ p->fileType() }; })
       // This should probably not be exposed in python since we provide automatic downcast:
       // .def("getTree", static_cast<std::shared_ptr<IFileTree>(FileTreeEntry::*)()>(&FileTreeEntry::astree))
       .def("name", &FileTreeEntry::name)

--- a/src/runner/pythonrunner.cpp
+++ b/src/runner/pythonrunner.cpp
@@ -826,6 +826,9 @@ BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(updateWithQuality, MOBase::GuessedValue<Q
 BOOST_PYTHON_MODULE(mobase)
 {
   PyEval_InitThreads();
+
+  bpy::import("PyQt5.QtCore");
+
   bpy::to_python_converter<QVariant, QVariant_to_python_obj>();
   QVariant_from_python_obj();
 

--- a/src/runner/pythonrunner.cpp
+++ b/src/runner/pythonrunner.cpp
@@ -972,9 +972,16 @@ BOOST_PYTHON_MODULE(mobase)
       .def("detach", &FileTreeEntry::detach)
       .def("moveTo", &FileTreeEntry::moveTo)
 
+      // Special methods:
+      .def("__eq__", +[](const FileTreeEntry* entry, QString other) {
+        return entry->compare(other) == 0;
+      })
+      .def("__eq__", +[](const FileTreeEntry* entry, std::shared_ptr<FileTreeEntry> other) {
+        return entry == other.get();
+      })
+
       // Special methods for debug:
-      .def("__str__", &FileTreeEntry::name)
-      .def("__repr__", +[](const FileTreeEntry* entry) { return "FileTreeEntry(" + entry->name() + ")"; })
+      .def("__repr__", +[](const FileTreeEntry* entry) { return "FileTreeEntry(\"" + entry->name() + "\")"; })
       ;
   }
 
@@ -1042,8 +1049,7 @@ BOOST_PYTHON_MODULE(mobase)
         static_cast<IFileTree::iterator(IFileTree::*)()>(&IFileTree::end)))
       .def("__len__", &IFileTree::size)
       .def("__bool__", +[](const IFileTree* tree) { return !tree->empty(); })
-      .def("__str__", &FileTreeEntry::name)
-      .def("__repr__", +[](const IFileTree* entry) { return "IFileTree(" + entry->name() + ")"; })
+      .def("__repr__", +[](const IFileTree* entry) { return "IFileTree(\"" + entry->name() + "\")"; })
       ;
   }
   

--- a/src/runner/pythonrunner.cpp
+++ b/src/runner/pythonrunner.cpp
@@ -697,7 +697,12 @@ struct Functor_converter<RET(PARAMS... )>
 
     RET operator()(const PARAMS &...params) {
       GILock lock;
-      return (RET) m_Callable(params...);
+      if constexpr (std::is_same_v<RET, void>) {
+        m_Callable(params...);
+      }
+      else {
+        return bpy::extract<RET>(m_Callable(params...));
+      }
     }
 
     boost::python::object m_Callable;

--- a/src/runner/pythonrunner.cpp
+++ b/src/runner/pythonrunner.cpp
@@ -1125,7 +1125,9 @@ BOOST_PYTHON_MODULE(mobase)
       .value("USER", MOBase::GUESS_USER)
       ;
 
-  bpy::class_<MOBase::GuessedValue<QString>, boost::noncopyable>("GuessedString", bpy::no_init)
+  bpy::class_<MOBase::GuessedValue<QString>, boost::noncopyable>("GuessedString")
+      .def(bpy::init<>())
+      .def(bpy::init<QString const&, EGuessQuality>())
       .def("update",
            static_cast<GuessedValue<QString>& (GuessedValue<QString>::*)(const QString&)>(&GuessedValue<QString>::update),
            bpy::return_self<>())
@@ -1136,6 +1138,7 @@ BOOST_PYTHON_MODULE(mobase)
       // Methods to simulate the assignment operator:
       .def("reset", +[](GuessedValue<QString>* gv) { *gv = GuessedValue<QString>(); }, bpy::return_self<>())
       .def("reset", +[](GuessedValue<QString>* gv, const QString& value, EGuessQuality eq) { *gv = GuessedValue<QString>(value, eq); }, bpy::return_self<>())
+      .def("reset", +[](GuessedValue<QString>* gv, const GuessedValue<QString>& other) { *gv = other; }, bpy::return_self<>())
 
       // Use an intermediate lambda to avoid having to register the std::function conversion:
       .def("setFilter", +[](GuessedValue<QString>* gv, bpy::object fn) { gv->setFilter(fn); })

--- a/src/runner/pythonrunner.cpp
+++ b/src/runner/pythonrunner.cpp
@@ -1053,6 +1053,7 @@ BOOST_PYTHON_MODULE(mobase)
       .def("downloadPath", bpy::pure_virtual(&IDownloadManager::downloadPath))
       ;
 
+  utils::register_sequence_container<std::vector<std::shared_ptr<const MOBase::FileTreeEntry>>>();
   bpy::class_<IInstallationManagerWrapper, boost::noncopyable>("IInstallationManager")
     .def("extractFile", bpy::pure_virtual(&IInstallationManager::extractFile))
     .def("extractFiles", bpy::pure_virtual(&IInstallationManager::extractFiles))

--- a/src/runner/pythonrunner.cpp
+++ b/src/runner/pythonrunner.cpp
@@ -70,14 +70,6 @@ private:
   template <class T>
   void appendIfInstance(bpy::object const& obj, QList<QObject*> &interfaces);
 
-  /**
-   * @brief Ensure that the given folder is in sys.path. Can be used
-   * after Py_Initialize().
-   *
-   * @param folder Folder to add to the path if missing.
-   */
-  void ensureFolderInPath(QString folder);
-
 private:
   std::map<QString, boost::python::object> m_PythonObjects;
   const MOBase::IOrganizer *m_MOInfo;

--- a/src/runner/pythonrunner.cpp
+++ b/src/runner/pythonrunner.cpp
@@ -1140,7 +1140,15 @@ BOOST_PYTHON_MODULE(mobase)
       // Use an intermediate lambda to avoid having to register the std::function conversion:
       .def("setFilter", +[](GuessedValue<QString>* gv, bpy::object fn) { gv->setFilter(fn); })
 
-      .def("variants", &MOBase::GuessedValue<QString>::variants, bpy::return_value_policy<bpy::copy_const_reference>())
+      // Exposing the set does not work, but even if it worked, we would lose the order since it would be
+      // converted to a python set() so we expose a cusotm iterator. This works because variants() returns
+      // a reference, otherwize this would be more complex to do (also, needs to use references instead of
+      // pointers instead of the lambda due to the range() requirements):
+      .def("variants", bpy::range<
+        bpy::return_value_policy<bpy::copy_const_reference>>(
+        +[](GuessedValue<QString> &gv) { return std::begin(gv.variants()); },
+        +[](GuessedValue<QString> &gv) { return std::end(gv.variants()); }
+        ))
       .def("__str__", &MOBase::GuessedValue<QString>::operator const QString&, bpy::return_value_policy<bpy::copy_const_reference>())
       ;
 

--- a/src/runner/pythonutils.h
+++ b/src/runner/pythonutils.h
@@ -146,6 +146,13 @@ namespace utils {
     }
   };
 
+  /**
+   * @brief Register from and to python converters for (at least) map, unordered_map and QMap.
+   *
+   * Any standard compliant associative container with key/value should work here.
+   *
+   * @tparam Map The container type to register.
+   */
   template <class Map>
   void register_associative_container() {
     bpy::to_python_converter<Map, map_to_python<Map>>();
@@ -155,6 +162,13 @@ namespace utils {
       , bpy::type_id<Map>());
   };
 
+  /**
+   * @brief Register from and to python converters for (at least) set, unordered_set and QSet.
+   *
+   * Any standard compliant associative container with key should work here.
+   *
+   * @tparam Map The container type to register.
+   */
   template <class Container>
   void register_set_container() {
     bpy::to_python_converter<Container, set_to_python<Container>>();
@@ -164,6 +178,13 @@ namespace utils {
       , bpy::type_id<Container>());
   };
 
+  /**
+   * @brief Register from and to python converters for sequence container.
+   *
+   * Any standard compliant container should work here.
+   *
+   * @tparam Map The container type to register.
+   */
   template <class Container>
   void register_sequence_container() {
     bpy::to_python_converter<Container, container_to_python_list<Container>>();
@@ -172,8 +193,6 @@ namespace utils {
       , &container_from_python_list<Container>::construct
       , bpy::type_id<Container>());
   };
-
-
 
 }
 

--- a/src/runner/pythonutils.h
+++ b/src/runner/pythonutils.h
@@ -5,14 +5,16 @@
 
 namespace utils {
 
+  namespace bpy = boost::python;
+
   template <class Map>
   struct map_to_python {
     static PyObject* convert(const Map& map) {
-      boost::python::dict result;
+      bpy::dict result;
       for (auto& entry : map) {
-        result[boost::python::object{ entry.first }] = boost::python::object{ entry.second };
+        result[bpy::object{ entry.first }] = bpy::object{ entry.second };
       }
-      return boost::python::incref(result.ptr());
+      return bpy::incref(result.ptr());
     }
   };
 
@@ -26,15 +28,97 @@ namespace utils {
       return PyDict_Check(objPtr) ? objPtr : nullptr;
     }
 
-    static void construct(PyObject* objPtr, boost::python::converter::rvalue_from_python_stage1_data* data) {
-      void* storage = ((boost::python::converter::rvalue_from_python_storage<Map>*)data)->storage.bytes;
+    static void construct(PyObject* objPtr, bpy::converter::rvalue_from_python_stage1_data* data) {
+      void* storage = ((bpy::converter::rvalue_from_python_storage<Map>*)data)->storage.bytes;
       Map* result = new (storage) Map();
-      boost::python::dict source(boost::python::handle<>(boost::python::borrowed(objPtr)));
-      boost::python::list keys = source.keys();
-      int len = boost::python::len(keys);
+      bpy::dict source(bpy::handle<>(bpy::borrowed(objPtr)));
+      bpy::list keys = source.keys();
+      int len = bpy::len(keys);
       for (int i = 0; i < len; ++i) {
-        boost::python::object pyKey = keys[i];
-        (*result)[boost::python::extract<key_type>(pyKey)] = boost::python::extract<value_type>(source[pyKey]);
+        bpy::object pyKey = keys[i];
+        (*result)[bpy::extract<key_type>(pyKey)] = bpy::extract<value_type>(source[pyKey]);
+      }
+
+      data->convertible = storage;
+    }
+  };
+
+  template <class Container>
+  struct container_to_python_list {
+    static PyObject* convert(const Container& container) {
+      bpy::list pyList;
+
+      try {
+        for (auto& item : container)
+          pyList.append(item);
+      }
+      catch (const bpy::error_already_set&) {
+        reportPythonError();
+      }
+
+      return bpy::incref(pyList.ptr());
+    }
+  };
+
+
+  template <class Container>
+  struct container_from_python_list {
+
+    using value_type = typename Container::value_type;
+
+    static void* convertible(PyObject* objPtr) {
+      if (PySequence_Check(objPtr)) return objPtr;
+      return nullptr;
+    }
+
+    static void construct(PyObject* objPtr, bpy::converter::rvalue_from_python_stage1_data* data) {
+      void* storage = ((bpy::converter::rvalue_from_python_storage<Container>*)data)->storage.bytes;
+      Container* result = new (storage) Container();
+      bpy::list source(bpy::handle<>(bpy::borrowed(objPtr)));
+      int length = bpy::len(source);
+      for (int i = 0; i < length; ++i) {
+        result->push_back(bpy::extract<value_type>(source[i]));
+      }
+
+      data->convertible = storage;
+    }
+  };
+
+  template <class Container>
+  struct set_to_python {
+    static PyObject* convert(const Container& container) {
+      bpy::list pyList;
+
+      try {
+        for (auto& item : container)
+          pyList.append(item);
+      }
+      catch (const bpy::error_already_set&) {
+        reportPythonError();
+      }
+
+      return bpy::incref(pyList.ptr());
+    }
+  };
+
+
+  template <class Container>
+  struct set_from_python {
+
+    using value_type = typename Container::value_type;
+
+    static void* convertible(PyObject* objPtr) {
+      if (PySequence_Check(objPtr)) return objPtr;
+      return nullptr;
+    }
+
+    static void construct(PyObject* objPtr, bpy::converter::rvalue_from_python_stage1_data* data) {
+      void* storage = ((bpy::converter::rvalue_from_python_storage<Container>*)data)->storage.bytes;
+      Container* result = new (storage) Container();
+      bpy::list source(bpy::handle<>(bpy::borrowed(objPtr)));
+      int length = bpy::len(source);
+      for (int i = 0; i < length; ++i) {
+        result->insert(bpy::extract<value_type>(source[i]));
       }
 
       data->convertible = storage;
@@ -42,15 +126,32 @@ namespace utils {
   };
 
   template <class Map>
-  void register_map() {
-
-    boost::python::to_python_converter<Map, map_to_python<Map>>();
-
-    boost::python::converter::registry::push_back(
+  void register_associative_container() {
+    bpy::to_python_converter<Map, map_to_python<Map>>();
+    bpy::converter::registry::push_back(
       &map_from_python<Map>::convertible
       , &map_from_python<Map>::construct
-      , boost::python::type_id<Map>());
+      , bpy::type_id<Map>());
   };
+
+  template <class Container>
+  void register_set_container() {
+    bpy::to_python_converter<Container, set_to_python<Container>>();
+    bpy::converter::registry::push_back(
+      &set_from_python<Container>::convertible
+      , &set_from_python<Container>::construct
+      , bpy::type_id<Container>());
+  };
+
+  template <class Container>
+  void register_sequence_container() {
+    bpy::to_python_converter<Container, container_to_python_list<Container>>();
+    bpy::converter::registry::push_back(
+      &container_from_python_list<Container>::convertible
+      , &container_from_python_list<Container>::construct
+      , bpy::type_id<Container>());
+  };
+
 
 
 }

--- a/src/runner/pythonutils.h
+++ b/src/runner/pythonutils.h
@@ -1,0 +1,58 @@
+#ifndef PYTHONRUNNER_UTILS_H
+#define PYTHONRUNNER_UTILS_H
+
+#include <boost/python.hpp>
+
+namespace utils {
+
+  template <class Map>
+  struct map_to_python {
+    static PyObject* convert(const Map& map) {
+      boost::python::dict result;
+      for (auto& entry : map) {
+        result[boost::python::object{ entry.first }] = boost::python::object{ entry.second };
+      }
+      return boost::python::incref(result.ptr());
+    }
+  };
+
+  template <class Map>
+  struct map_from_python {
+
+    using key_type = typename Map::key_type;
+    using value_type = typename Map::mapped_type;
+
+    static void* convertible(PyObject* objPtr) {
+      return PyDict_Check(objPtr) ? objPtr : nullptr;
+    }
+
+    static void construct(PyObject* objPtr, boost::python::converter::rvalue_from_python_stage1_data* data) {
+      void* storage = ((boost::python::converter::rvalue_from_python_storage<Map>*)data)->storage.bytes;
+      Map* result = new (storage) Map();
+      boost::python::dict source(boost::python::handle<>(boost::python::borrowed(objPtr)));
+      boost::python::list keys = source.keys();
+      int len = boost::python::len(keys);
+      for (int i = 0; i < len; ++i) {
+        boost::python::object pyKey = keys[i];
+        (*result)[boost::python::extract<key_type>(pyKey)] = boost::python::extract<value_type>(source[pyKey]);
+      }
+
+      data->convertible = storage;
+    }
+  };
+
+  template <class Map>
+  void register_map() {
+
+    boost::python::to_python_converter<Map, map_to_python<Map>>();
+
+    boost::python::converter::registry::push_back(
+      &map_from_python<Map>::convertible
+      , &map_from_python<Map>::construct
+      , boost::python::type_id<Map>());
+  };
+
+
+}
+
+#endif

--- a/src/runner/tuple_helper.h
+++ b/src/runner/tuple_helper.h
@@ -20,13 +20,10 @@ namespace boost {
 
     private:
 
-      template <std::size_t I0, std::size_t... Is>
-      static void convert_impl(const TTuple& c_tuple, list& values, std::index_sequence<I0, Is... >) {
-        values.append(std::get<I0>(c_tuple));
-        convert_impl(c_tuple, values, std::index_sequence<Is... >{});
+      template <std::size_t... Is>
+      static void convert_impl(const TTuple& c_tuple, list& values, std::index_sequence<Is... >) {
+        (values.append(std::get<Is>(c_tuple)), ...);
       }
-
-      static void convert_impl(const TTuple&, list& values, std::index_sequence<>) {}
 
     };
 
@@ -99,4 +96,4 @@ namespace boost {
   }
 } //boost::python
 
-#endif//TUPLES_HPP_16_JAN_2007
+#endif

--- a/src/runner/tuple_helper.h
+++ b/src/runner/tuple_helper.h
@@ -1,0 +1,253 @@
+// From: https://pyplusplus.readthedocs.io/en/latest/troubleshooting_guide/automatic_conversion/tuples.hpp.html
+// Copyright 2004-2007 Roman Yakovenko.
+// Distributed under the Boost Software License, Version 1.0. (See
+// accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+#ifndef TUPLES_HPP_16_JAN_2007
+#define TUPLES_HPP_16_JAN_2007
+
+#include <boost/python.hpp>
+#include <boost/tuple/tuple.hpp>
+#include <boost/python/object.hpp> //len function
+#include <boost/mpl/int.hpp>
+#include <boost/mpl/next.hpp>
+
+/**
+ * Converts boost::tuples::tuple<...> to\from Python tuple
+ *
+ * The conversion is done "on-the-fly", you should only register the conversion
+ * with your tuple classes.
+ * For example:
+ *
+ *  typedef boost::tuples::tuple< int, double, std::string > triplet;
+ *  boost::python::register_tuple< triplet >();
+ *
+ * That's all. After this point conversion to\from next types will be handled
+ * by Boost.Python library:
+ *
+ *   triplet
+ *   triplet& ( return type only )
+ *   const triplet
+ *   const triplet&
+ *
+ * Implementation description.
+ *  The conversion uses Boost.Python custom r-value converters. r-value converters
+ * is very powerful and undocumented feature of the library. The only documentation
+ * we have is http://boost.org/libs/python/doc/v2/faq.html#custom_string .
+ *
+ *  The conversion consists from two parts: "to" and "from".
+ *
+ *  "To" conversion
+ * The "to" part is pretty easy and well documented ( http://docs.python.org/api/api.html ).
+ * You should use Python C API to create an instance of a class and than you
+ * initialize the relevant members of the instance.
+ *
+ *  "From" conversion
+ * Lets start from analyzing one of the use case Boost.Python library have to
+ * deal with:
+ *
+ *   void do_smth( const triplet& arg ){...}
+ *
+ * In order to allow calling this function from Python, the library should keep
+ * parameter "arg" alive until the function returns. In other words, the library
+ * should provide instances life-time management. The provided interface is not
+ * ideal and could be improved. You have to implement two functions:
+ *
+ *  void* convertible( PyObject* obj )
+ *    Checks whether the "obj" could be converted to an instance of the desired
+ *    class. If true, the function should return "obj", otherwise NULL
+ *
+ *  void construct( PyObject* obj, converter::rvalue_from_python_stage1_data* data)
+ *    Constructs the instance of the desired class. This function will be called
+ *    if and only if "convertible" function returned true. The first argument
+ *    is Python object, which was passed as parameter to "convertible" function.
+ *    The second object is some kind of memory allocator for one object. Basically
+ *    it keeps a memory chunk. You will use the memory for object allocation.
+ *
+ *    For some unclear for me reason, the library implements "C style Inheritance"
+ *    ( http://www.embedded.com/97/fe29712.htm ). So, in order to create new
+ *    object in the storage you have to cast to the "right" class:
+ *
+ *      typedef converter::rvalue_from_python_storage<your_type_t> storage_t;
+ *      storage_t* the_storage = reinterpret_cast<storage_t*>( data );
+ *      void* memory_chunk = the_storage->storage.bytes;
+ *
+ *    "memory_chunk" points to the memory, where the instance will be allocated.
+ *
+ *    In order to create object at specific location, you should use placement new
+ *    operator:
+ *
+ *      your_type_t* instance = new (memory_chunk) your_type_t();
+ *
+ *    Now, you can continue to initialize the instance.
+ *
+ *      instance->set_xyz = read xyz from obj
+ *
+ *    If "your_type_t" constructor requires some arguments, "read" the Python
+ *    object before you call the constructor:
+ *
+ *      xyz_type xyz = read xyz from obj
+ *      your_type_t* instance = new (memory_chunk) your_type_t(xyz);
+ *
+ *  Hint:
+ * In most case you don't really need\have to work with C Python API. Let
+ * Boost.Python library to do some work for you!
+ *
+ **/
+
+namespace boost {
+  namespace python {
+
+    namespace details {
+
+      //Small helper function, introduced to allow short syntax for index incrementing
+      template< int index>
+      typename mpl::next< mpl::int_< index > >::type increment_index() {
+        typedef typename mpl::next< mpl::int_< index > >::type next_index_type;
+        return next_index_type();
+      }
+
+    }
+
+    template< class TTuple >
+    struct to_py_tuple {
+
+      typedef mpl::int_< tuples::length< TTuple >::value > length_type;
+
+      static PyObject* convert(const TTuple& c_tuple) {
+        list values;
+        //add all c_tuple items to "values" list
+        convert_impl(c_tuple, values, mpl::int_< 0 >(), length_type());
+        //create Python tuple from the list
+        return incref(python::tuple(values).ptr());
+      }
+
+    private:
+
+      template< int index, int length >
+      static void
+        convert_impl(const TTuple& c_tuple, list& values, mpl::int_< index >, mpl::int_< length >) {
+        values.append(c_tuple.template get< index >());
+        convert_impl(c_tuple, values, details::increment_index<index>(), length_type());
+      }
+
+      template< int length >
+      static void
+        convert_impl(const TTuple&, list& values, mpl::int_< length >, mpl::int_< length >)
+      {}
+
+    };
+
+
+    template< class TTuple>
+    struct from_py_sequence {
+
+      typedef TTuple tuple_type;
+
+      typedef mpl::int_< tuples::length< TTuple >::value > length_type;
+
+      static void*
+        convertible(PyObject* py_obj) {
+
+        if (!PySequence_Check(py_obj)) {
+          return 0;
+        }
+
+        if (!PyObject_HasAttrString(py_obj, "__len__")) {
+          return 0;
+        }
+
+        python::object py_sequence(handle<>(borrowed(py_obj)));
+
+        if (tuples::length< TTuple >::value != len(py_sequence)) {
+          return 0;
+        }
+
+        if (convertible_impl(py_sequence, mpl::int_< 0 >(), length_type())) {
+          return py_obj;
+        }
+        else {
+          return 0;
+        }
+      }
+
+      static void
+        construct(PyObject* py_obj, converter::rvalue_from_python_stage1_data* data) {
+        typedef converter::rvalue_from_python_storage<TTuple> storage_t;
+        storage_t* the_storage = reinterpret_cast<storage_t*>(data);
+        void* memory_chunk = the_storage->storage.bytes;
+        TTuple* c_tuple = new (memory_chunk) TTuple();
+        data->convertible = memory_chunk;
+
+        python::object py_sequence(handle<>(borrowed(py_obj)));
+        construct_impl(py_sequence, *c_tuple, mpl::int_< 0 >(), length_type());
+      }
+
+      static TTuple to_c_tuple(PyObject* py_obj) {
+        if (!convertible(py_obj)) {
+          throw std::runtime_error("Unable to construct boost::tuples::tuple from Python object!");
+        }
+        TTuple c_tuple;
+        python::object py_sequence(handle<>(borrowed(py_obj)));
+        construct_impl(py_sequence, c_tuple, mpl::int_< 0 >(), length_type());
+        return c_tuple;
+      }
+
+    private:
+
+      template< int index, int length >
+      static bool
+        convertible_impl(const python::object& py_sequence, mpl::int_< index >, mpl::int_< length >) {
+
+        typedef typename tuples::element< index, TTuple>::type element_type;
+
+        object element = py_sequence[index];
+        extract<element_type> type_checker(element);
+        if (!type_checker.check()) {
+          return false;
+        }
+        else {
+          return convertible_impl(py_sequence, details::increment_index<index>(), length_type());
+        }
+      }
+
+      template< int length >
+      static bool
+        convertible_impl(const python::object& py_sequence, mpl::int_< length >, mpl::int_< length >) {
+        return true;
+      }
+
+      template< int index, int length >
+      static void
+        construct_impl(const python::object& py_sequence, TTuple& c_tuple, mpl::int_< index >, mpl::int_< length >) {
+
+        typedef typename tuples::element< index, TTuple>::type element_type;
+
+        object element = py_sequence[index];
+        c_tuple.template get< index >() = extract<element_type>(element);
+
+        construct_impl(py_sequence, c_tuple, details::increment_index<index>(), length_type());
+      }
+
+      template< int length >
+      static void
+        construct_impl(const python::object& py_sequence, TTuple& c_tuple, mpl::int_< length >, mpl::int_< length >)
+      {}
+
+    };
+
+    template< class TTuple>
+    void register_tuple() {
+
+      to_python_converter< TTuple, to_py_tuple<TTuple> >();
+
+      converter::registry::push_back(&from_py_sequence<TTuple>::convertible
+        , &from_py_sequence<TTuple>::construct
+        , type_id<TTuple>());
+    };
+
+  }
+} //boost::python
+
+#endif//TUPLES_HPP_16_JAN_2007

--- a/src/runner/tuple_helper.h
+++ b/src/runner/tuple_helper.h
@@ -1,154 +1,43 @@
-// From: https://pyplusplus.readthedocs.io/en/latest/troubleshooting_guide/automatic_conversion/tuples.hpp.html
-// Copyright 2004-2007 Roman Yakovenko.
-// Distributed under the Boost Software License, Version 1.0. (See
-// accompanying file LICENSE_1_0.txt or copy at
-// http://www.boost.org/LICENSE_1_0.txt)
-
-#ifndef TUPLES_HPP_16_JAN_2007
-#define TUPLES_HPP_16_JAN_2007
+#ifndef TUPLE_HELPER_H
+#define TUPLE_HELPER_H
 
 #include <boost/python.hpp>
-#include <boost/tuple/tuple.hpp>
 #include <boost/python/object.hpp> //len function
-#include <boost/mpl/int.hpp>
-#include <boost/mpl/next.hpp>
-
-/**
- * Converts boost::tuples::tuple<...> to\from Python tuple
- *
- * The conversion is done "on-the-fly", you should only register the conversion
- * with your tuple classes.
- * For example:
- *
- *  typedef boost::tuples::tuple< int, double, std::string > triplet;
- *  boost::python::register_tuple< triplet >();
- *
- * That's all. After this point conversion to\from next types will be handled
- * by Boost.Python library:
- *
- *   triplet
- *   triplet& ( return type only )
- *   const triplet
- *   const triplet&
- *
- * Implementation description.
- *  The conversion uses Boost.Python custom r-value converters. r-value converters
- * is very powerful and undocumented feature of the library. The only documentation
- * we have is http://boost.org/libs/python/doc/v2/faq.html#custom_string .
- *
- *  The conversion consists from two parts: "to" and "from".
- *
- *  "To" conversion
- * The "to" part is pretty easy and well documented ( http://docs.python.org/api/api.html ).
- * You should use Python C API to create an instance of a class and than you
- * initialize the relevant members of the instance.
- *
- *  "From" conversion
- * Lets start from analyzing one of the use case Boost.Python library have to
- * deal with:
- *
- *   void do_smth( const triplet& arg ){...}
- *
- * In order to allow calling this function from Python, the library should keep
- * parameter "arg" alive until the function returns. In other words, the library
- * should provide instances life-time management. The provided interface is not
- * ideal and could be improved. You have to implement two functions:
- *
- *  void* convertible( PyObject* obj )
- *    Checks whether the "obj" could be converted to an instance of the desired
- *    class. If true, the function should return "obj", otherwise NULL
- *
- *  void construct( PyObject* obj, converter::rvalue_from_python_stage1_data* data)
- *    Constructs the instance of the desired class. This function will be called
- *    if and only if "convertible" function returned true. The first argument
- *    is Python object, which was passed as parameter to "convertible" function.
- *    The second object is some kind of memory allocator for one object. Basically
- *    it keeps a memory chunk. You will use the memory for object allocation.
- *
- *    For some unclear for me reason, the library implements "C style Inheritance"
- *    ( http://www.embedded.com/97/fe29712.htm ). So, in order to create new
- *    object in the storage you have to cast to the "right" class:
- *
- *      typedef converter::rvalue_from_python_storage<your_type_t> storage_t;
- *      storage_t* the_storage = reinterpret_cast<storage_t*>( data );
- *      void* memory_chunk = the_storage->storage.bytes;
- *
- *    "memory_chunk" points to the memory, where the instance will be allocated.
- *
- *    In order to create object at specific location, you should use placement new
- *    operator:
- *
- *      your_type_t* instance = new (memory_chunk) your_type_t();
- *
- *    Now, you can continue to initialize the instance.
- *
- *      instance->set_xyz = read xyz from obj
- *
- *    If "your_type_t" constructor requires some arguments, "read" the Python
- *    object before you call the constructor:
- *
- *      xyz_type xyz = read xyz from obj
- *      your_type_t* instance = new (memory_chunk) your_type_t(xyz);
- *
- *  Hint:
- * In most case you don't really need\have to work with C Python API. Let
- * Boost.Python library to do some work for you!
- *
- **/
 
 namespace boost {
   namespace python {
 
-    namespace details {
-
-      //Small helper function, introduced to allow short syntax for index incrementing
-      template< int index>
-      typename mpl::next< mpl::int_< index > >::type increment_index() {
-        typedef typename mpl::next< mpl::int_< index > >::type next_index_type;
-        return next_index_type();
-      }
-
-    }
-
-    template< class TTuple >
+    template <class TTuple>
     struct to_py_tuple {
-
-      typedef mpl::int_< tuples::length< TTuple >::value > length_type;
 
       static PyObject* convert(const TTuple& c_tuple) {
         list values;
         //add all c_tuple items to "values" list
-        convert_impl(c_tuple, values, mpl::int_< 0 >(), length_type());
+        convert_impl(c_tuple, values, std::make_index_sequence<std::tuple_size_v<TTuple>>{});
         //create Python tuple from the list
         return incref(python::tuple(values).ptr());
       }
 
     private:
 
-      template< int index, int length >
-      static void
-        convert_impl(const TTuple& c_tuple, list& values, mpl::int_< index >, mpl::int_< length >) {
-        values.append(c_tuple.template get< index >());
-        convert_impl(c_tuple, values, details::increment_index<index>(), length_type());
+      template <std::size_t I0, std::size_t... Is>
+      static void convert_impl(const TTuple& c_tuple, list& values, std::index_sequence<I0, Is... >) {
+        values.append(std::get<I0>(c_tuple));
+        convert_impl(c_tuple, values, std::index_sequence<Is... >{});
       }
 
-      template< int length >
-      static void
-        convert_impl(const TTuple&, list& values, mpl::int_< length >, mpl::int_< length >)
-      {}
+      static void convert_impl(const TTuple&, list& values, std::index_sequence<>) {}
 
     };
 
 
-    template< class TTuple>
+    template <class TTuple>
     struct from_py_sequence {
 
-      typedef TTuple tuple_type;
+      using tuple_type = TTuple;
+      using index_sequence = std::make_index_sequence<std::tuple_size_v<TTuple>>;
 
-      typedef mpl::int_< tuples::length< TTuple >::value > length_type;
-
-      static void*
-        convertible(PyObject* py_obj) {
+      static void* convertible(PyObject* py_obj) {
 
         if (!PySequence_Check(py_obj)) {
           return 0;
@@ -160,11 +49,11 @@ namespace boost {
 
         python::object py_sequence(handle<>(borrowed(py_obj)));
 
-        if (tuples::length< TTuple >::value != len(py_sequence)) {
+        if (std::tuple_size_v<TTuple> != len(py_sequence)) {
           return 0;
         }
 
-        if (convertible_impl(py_sequence, mpl::int_< 0 >(), length_type())) {
+        if (convertible_impl(py_sequence, index_sequence{})) {
           return py_obj;
         }
         else {
@@ -172,8 +61,7 @@ namespace boost {
         }
       }
 
-      static void
-        construct(PyObject* py_obj, converter::rvalue_from_python_stage1_data* data) {
+      static void construct(PyObject* py_obj, converter::rvalue_from_python_stage1_data* data) {
         typedef converter::rvalue_from_python_storage<TTuple> storage_t;
         storage_t* the_storage = reinterpret_cast<storage_t*>(data);
         void* memory_chunk = the_storage->storage.bytes;
@@ -181,59 +69,20 @@ namespace boost {
         data->convertible = memory_chunk;
 
         python::object py_sequence(handle<>(borrowed(py_obj)));
-        construct_impl(py_sequence, *c_tuple, mpl::int_< 0 >(), length_type());
-      }
-
-      static TTuple to_c_tuple(PyObject* py_obj) {
-        if (!convertible(py_obj)) {
-          throw std::runtime_error("Unable to construct boost::tuples::tuple from Python object!");
-        }
-        TTuple c_tuple;
-        python::object py_sequence(handle<>(borrowed(py_obj)));
-        construct_impl(py_sequence, c_tuple, mpl::int_< 0 >(), length_type());
-        return c_tuple;
+        construct_impl(py_sequence, *c_tuple, index_sequence{});
       }
 
     private:
 
-      template< int index, int length >
-      static bool
-        convertible_impl(const python::object& py_sequence, mpl::int_< index >, mpl::int_< length >) {
-
-        typedef typename tuples::element< index, TTuple>::type element_type;
-
-        object element = py_sequence[index];
-        extract<element_type> type_checker(element);
-        if (!type_checker.check()) {
-          return false;
-        }
-        else {
-          return convertible_impl(py_sequence, details::increment_index<index>(), length_type());
-        }
+      template <std::size_t... Is>
+      static bool convertible_impl(const python::object& py_sequence, std::index_sequence<Is... >) {
+        return (... && extract<std::tuple_element_t<Is, tuple_type>>(py_sequence[Is]).check());
       }
 
-      template< int length >
-      static bool
-        convertible_impl(const python::object& py_sequence, mpl::int_< length >, mpl::int_< length >) {
-        return true;
+      template <std::size_t... Is>
+      static void construct_impl(const python::object& py_sequence, TTuple& c_tuple, std::index_sequence<Is... >) {
+        c_tuple = tuple_type{ extract<std::tuple_element_t<Is, tuple_type>>(py_sequence[Is])... };
       }
-
-      template< int index, int length >
-      static void
-        construct_impl(const python::object& py_sequence, TTuple& c_tuple, mpl::int_< index >, mpl::int_< length >) {
-
-        typedef typename tuples::element< index, TTuple>::type element_type;
-
-        object element = py_sequence[index];
-        c_tuple.template get< index >() = extract<element_type>(element);
-
-        construct_impl(py_sequence, c_tuple, details::increment_index<index>(), length_type());
-      }
-
-      template< int length >
-      static void
-        construct_impl(const python::object& py_sequence, TTuple& c_tuple, mpl::int_< length >, mpl::int_< length >)
-      {}
 
     };
 

--- a/src/runner/uibasewrappers.h
+++ b/src/runner/uibasewrappers.h
@@ -443,12 +443,12 @@ struct IModInterfaceWrapper: MOBase::IModInterface, boost::python::wrapper<MOBas
   virtual void setNexusID(int nexusID) override { this->get_override("setNexusID")(nexusID); }
   virtual void setInstallationFile(const QString &fileName) override { this->get_override("setInstallationFile")(fileName); }
   virtual void addNexusCategory(int categoryID) override { this->get_override("addNexusCategory")(categoryID); }
-  virtual void setGameName(const QString &gameName) override { this->get_override("setGameName")(gameName); }
+  virtual void setGamePlugin(const MOBase::IPluginGame *gamePlugin) override { this->get_override("setGamePlugin")(gamePlugin); }
   virtual bool setName(const QString &name) override { return this->get_override("setName")(name); }
   virtual bool remove() override { return this->get_override("remove")(); }
   virtual void addCategory(const QString &categoryName) override { this->get_override("addCategory")(categoryName); }
   virtual bool removeCategory(const QString &categoryName) override { return this->get_override("removeCategory")(categoryName); }
-  virtual QStringList categories() override { return this->get_override("categories")(); }
+  virtual QStringList categories() const override { return this->get_override("categories")(); }
 };
 
 

--- a/src/runner/uibasewrappers.h
+++ b/src/runner/uibasewrappers.h
@@ -445,7 +445,7 @@ struct IModInterfaceWrapper: MOBase::IModInterface, boost::python::wrapper<MOBas
   virtual void setNexusID(int nexusID) override { this->get_override("setNexusID")(nexusID); }
   virtual void setInstallationFile(const QString &fileName) override { this->get_override("setInstallationFile")(fileName); }
   virtual void addNexusCategory(int categoryID) override { this->get_override("addNexusCategory")(categoryID); }
-  virtual void setGamePlugin(const MOBase::IPluginGame *gamePlugin) override { this->get_override("setGamePlugin")(gamePlugin); }
+  virtual void setGameName(const QString& gameName) override { this->get_override("setGameName")(gameName); }
   virtual bool setName(const QString &name) override { return this->get_override("setName")(name); }
   virtual bool remove() override { return this->get_override("remove")(); }
   virtual void addCategory(const QString &categoryName) override { this->get_override("addCategory")(categoryName); }

--- a/src/runner/uibasewrappers.h
+++ b/src/runner/uibasewrappers.h
@@ -23,6 +23,7 @@
 #include <imodlist.h>
 #include <isavegame.h>
 #include <isavegameinfowidget.h>
+#include "ifiletree.h"
 
 #include "error.h"
 #include "gilock.h"
@@ -427,10 +428,11 @@ struct IModRepositoryBridgeWrapper: MOBase::IModRepositoryBridge, boost::python:
 
 struct IInstallationManagerWrapper: MOBase::IInstallationManager, boost::python::wrapper<MOBase::IInstallationManager>
 {
-  virtual QString extractFile(const QString &fileName) { return this->get_override("extractFile")(fileName); }
-  virtual QStringList extractFiles(const QStringList &files, bool flatten) { return this->get_override("extractFiles")(files, flatten); }
-  virtual MOBase::IPluginInstaller::EInstallResult installArchive(MOBase::GuessedValue<QString> &modName, const QString &archiveFile, const int &modId = 0) { return this->get_override("installArchive")(modName, archiveFile, modId); }
-  virtual void setURL(QString const &url) { this->get_override("setURL")(url); }
+  virtual QString extractFile(std::shared_ptr<const MOBase::FileTreeEntry> entry) override { return this->get_override("extractFile")(entry); }
+  virtual QStringList extractFiles(std::vector<std::shared_ptr<const MOBase::FileTreeEntry>> const& entries) override { return this->get_override("extractFiles")(entries); }
+  virtual MOBase::IPluginInstaller::EInstallResult installArchive(MOBase::GuessedValue<QString> &modName, const QString &archiveFile, int modId = 0) override {
+    return this->get_override("installArchive")(modName, archiveFile, modId); }
+  virtual void setURL(QString const &url) override { this->get_override("setURL")(url); }
 };
 
 struct IModInterfaceWrapper: MOBase::IModInterface, boost::python::wrapper<MOBase::IModInterface>

--- a/src/runner/variant_helper.h
+++ b/src/runner/variant_helper.h
@@ -2,13 +2,9 @@
 #define VARIANT_HELPER_H
 
 #include <boost/python.hpp>
-#include <boost/variant.hpp>
-#include <boost/python/object.hpp> //len function
-#include <boost/mpl/int.hpp>
-#include <boost/mpl/next.hpp>
 
 /**
- * Creates boost::variant from python object. Greatly inspired by register_tuple<>.
+ * Register variant(s) from and to python object. Greatly inspired by register_tuple<>.
  */
 
 namespace boost {
@@ -18,7 +14,7 @@ namespace boost {
     struct to_py_variant {
 
       static PyObject* convert(const TVariant& c_variant) {
-        object value = boost::apply_visitor([](auto const& value) {
+        object value = std::visit([](auto const& value) {
           return object{ value };
         }, c_variant);
         //create Python object from the list

--- a/src/runner/variant_helper.h
+++ b/src/runner/variant_helper.h
@@ -14,6 +14,24 @@
 namespace boost {
   namespace python {
 
+    template <class>
+    struct to_py_variant;
+
+    template <class... Args>
+    struct to_py_variant<boost::variant<Args... >> {
+
+      using variant_type = boost::variant<Args... >;
+
+      static PyObject* convert(const variant_type& c_variant) {
+        object value = boost::apply_visitor([](auto const& value) {
+          return object{ value };
+        }, c_variant);
+        //create Python object from the list
+        return incref(value.ptr());
+      }
+
+    };
+
     template <class TVariant>
     struct variant_from_python;
    
@@ -88,6 +106,9 @@ namespace boost {
 
     template< class TVariant>
     void register_variant() {
+
+      to_python_converter<TVariant, to_py_variant<TVariant>>();
+
       converter::registry::push_back(&variant_from_python<TVariant>::convertible
         , &variant_from_python<TVariant>::construct
         , type_id<TVariant>());

--- a/src/runner/variant_helper.h
+++ b/src/runner/variant_helper.h
@@ -1,0 +1,99 @@
+#ifndef VARIANT_HELPER_H
+#define VARIANT_HELPER_H
+
+#include <boost/python.hpp>
+#include <boost/variant.hpp>
+#include <boost/python/object.hpp> //len function
+#include <boost/mpl/int.hpp>
+#include <boost/mpl/next.hpp>
+
+/**
+ * Creates boost::variant from python object. Greatly inspired by register_tuple<>.
+ */
+
+namespace boost {
+  namespace python {
+
+    template <class TVariant>
+    struct variant_from_python;
+   
+    template <class... Args>
+    struct variant_from_python<boost::variant<Args... >> {
+
+      using variant_type = boost::variant<Args... >;
+
+      static void* convertible(PyObject* py_obj) {
+
+        python::object obj(handle<>(borrowed(py_obj)));
+
+        if (impl<Args... >::convertible(obj)) {
+          return py_obj;
+        }
+        else {
+          return 0;
+        }
+      }
+
+      static void construct(PyObject* py_obj, converter::rvalue_from_python_stage1_data* data) {
+        typedef converter::rvalue_from_python_storage<variant_type> storage_t;
+        storage_t* the_storage = reinterpret_cast<storage_t*>(data);
+        void* memory_chunk = the_storage->storage.bytes;
+        variant_type* c_variant = new (memory_chunk) variant_type();
+        data->convertible = memory_chunk;
+
+        python::object obj(handle<>(borrowed(py_obj)));
+        impl<Args... >::construct(obj, *c_variant);
+      }
+
+    private:
+
+      template <class... >
+      struct impl;
+
+      template <>
+      struct impl<> {
+        static bool convertible(const python::object& obj) { return false; }
+        static void construct(const python::object& obj, variant_type& c_variant) {}
+      };
+
+      template <class UArg, class... UArgs>
+      struct impl<UArg, UArgs... > {
+
+        static bool convertible(const python::object& obj) {
+
+          extract<UArg> type_checker(obj);
+          if (type_checker.check()) {
+            return true;
+          }
+          else {
+            return impl<UArgs... >::convertible(obj);
+          }
+        }
+
+        static void construct(const python::object& obj, variant_type& c_variant) {
+
+          extract<UArg> type_checker(obj);
+
+          if (type_checker.check()) {
+            c_variant = type_checker();
+          }
+          else {
+            impl<UArgs... >::construct(obj, c_variant);
+          }
+        }
+
+      };
+
+    };
+
+    template< class TVariant>
+    void register_variant() {
+      converter::registry::push_back(&variant_from_python<TVariant>::convertible
+        , &variant_from_python<TVariant>::construct
+        , type_id<TVariant>());
+    };
+
+  }
+} //boost::python
+
+#endif//TUPLES_HPP_16_JAN_2007

--- a/src/runner/variant_helper.h
+++ b/src/runner/variant_helper.h
@@ -101,4 +101,4 @@ namespace boost {
   }
 } //boost::python
 
-#endif//TUPLES_HPP_16_JAN_2007
+#endif

--- a/src/runner/variant_helper.h
+++ b/src/runner/variant_helper.h
@@ -14,15 +14,10 @@
 namespace boost {
   namespace python {
 
-    template <class>
-    struct to_py_variant;
+    template <class TVariant>
+    struct to_py_variant {
 
-    template <class... Args>
-    struct to_py_variant<boost::variant<Args... >> {
-
-      using variant_type = boost::variant<Args... >;
-
-      static PyObject* convert(const variant_type& c_variant) {
+      static PyObject* convert(const TVariant& c_variant) {
         object value = boost::apply_visitor([](auto const& value) {
           return object{ value };
         }, c_variant);
@@ -35,10 +30,10 @@ namespace boost {
     template <class TVariant>
     struct variant_from_python;
    
-    template <class... Args>
-    struct variant_from_python<boost::variant<Args... >> {
+    template <template <class... > class VTemplate, class... Args>
+    struct variant_from_python<VTemplate<Args... >> {
 
-      using variant_type = boost::variant<Args... >;
+      using variant_type = VTemplate<Args... >;
 
       static void* convertible(PyObject* py_obj) {
 


### PR DESCRIPTION
**Important:** This PR depends on https://github.com/ModOrganizer2/modorganizer-uibase/pull/48

Content of the PR:

- Fix bindings following changes on `uibase`.
- Add interface for the new file tree implementation.
- Add new bindings for the installers, and fix existing ones.
    - `IPluginInstallerSimple`
    - `IPluginInstallerCustom`
- Fix or add missing bindings:
    - `GuessedString`
    - `FileInfo`
- Refactor some `boost::python` register stuff.