### PR TITLE
Allow implementation of python plugin as whole module.

### DIFF
--- a/src/proxy/proxypython.cpp
+++ b/src/proxy/proxypython.cpp
@@ -28,7 +28,6 @@ along with python proxy plugin.  If not, see <http://www.gnu.org/licenses/>.
 #include <QCoreApplication>
 #include "resource.h"
 
-
 using namespace MOBase;
 
 
@@ -214,11 +213,24 @@ QList<PluginSetting> ProxyPython::settings() const
 
 QStringList ProxyPython::pluginList(const QString &pluginPath) const
 {
-  QDirIterator iter(pluginPath, QStringList("*.py"));
+  QDir dir(pluginPath);
+  dir.setFilter(dir.filter() | QDir::NoDotAndDotDot);
+  QDirIterator iter(dir);
 
+  // Note: We put python script (.py) and directory names, not the __init__.py
+  // files in those since it is easier for the runner to import them.
   QStringList result;
   while (iter.hasNext()) {
-    result.append(iter.next());
+    QString name = iter.next();
+    QFileInfo info = iter.fileInfo();
+
+    if (info.isFile() && name.endsWith(".py")) {
+      result.append(name);
+    }
+    else if (info.isDir() && QDir(info.absoluteFilePath()).exists("__init__.py")) {
+      result.append(name);
+      // result.append(info.baseName());
+    }
   }
 
   return result;

--- a/src/runner/pythonrunner.cpp
+++ b/src/runner/pythonrunner.cpp
@@ -44,6 +44,11 @@ public:
 private:
 
   void initPath();
+  
+  /**
+   * @brief Ensure that the given folder is in sys.path.
+   */
+  void ensureFolderInPath(QString folder);
 
 private:
   std::map<QString, boost::python::object> m_PythonObjects;
@@ -1340,6 +1345,17 @@ void PythonRunner::initPath()
   Py_SetPath(paths.join(';').toStdWString().c_str());
 }
 
+void PythonRunner::ensureFolderInPath(QString folder) {
+  bpy::object sys = bpy::import("sys");
+  bpy::list sysPath = bpy::extract<bpy::list>(sys.attr("path"));
+
+  // Converting to QStringList for Qt::CaseInsensitive and because .index()
+  // raise an exception:
+  QStringList currentPath = bpy::extract<QStringList>(sysPath);
+  if (!currentPath.contains(folder, Qt::CaseInsensitive)) {
+    sysPath.insert(0, folder);
+  }
+}
 
 QList<QObject*> PythonRunner::instantiate(const QString &pluginName)
 {
@@ -1352,12 +1368,22 @@ QList<QObject*> PythonRunner::instantiate(const QString &pluginName)
     moduleNamespace["sys"] = sys;
     moduleNamespace["mobase"] = bpy::import("mobase");
 
-    std::string temp = ToString(pluginName);
-    if (handled_exec_file(temp.c_str(), moduleNamespace)) {
-      reportPythonError();
-      return QList<QObject*>();
+    if (pluginName.endsWith(".py")) {
+      std::string temp = ToString(pluginName);
+      if (handled_exec_file(temp.c_str(), moduleNamespace)) {
+        reportPythonError();
+        return QList<QObject*>();
+      }
+      m_PythonObjects[pluginName] = moduleNamespace["createPlugin"]();
     }
-    m_PythonObjects[pluginName] = moduleNamespace["createPlugin"]();
+    else {
+      // Retrieve the module name:
+      QStringList parts = pluginName.split("/");
+      std::string moduleName = ToString(parts.takeLast());
+      ensureFolderInPath(parts.join("/"));
+      bpy::object createPlugin = bpy::import(moduleName.c_str()).attr("createPlugin");
+      m_PythonObjects[pluginName] = createPlugin();
+    }
 
     bpy::object pluginObj = m_PythonObjects[pluginName];
     QList<QObject *> interfaceList;


### PR DESCRIPTION
This PR allows creation of python plugin as whole module (folder). The idea is quite simple:

- In `ProxyPython`, list both `.py` files and folder containing a `__init__.py` file.
- In `PythonRunner`, if the given "filename" ends with a `.py`, import as usual, otherwise, add the parent directory to `sys.path` (cannot use `Py_SetPath` here apparently since this is after `Py_Initialize()`) after checking if it was already in, and then load the module and call `createPlugin()`.

**Why this change?**  

- It allows python plugin creator to provide their module as a whole folder than can be dropped in the `plugins/` folder of MO2 without having to copy the `.py` file to `plugins/` and everything else to `plugins/data`.
- As a consequence, the `plugins/data` folder can be kept quite clean. Current python module from MO2 could be switch to this new format without too many issues.
- This reduces the risk of conflicting files between plugins (unless both plugins use the same name... ), so you could keep the README, the LICENSE, or whatever alongside the plugin.

**Note:** This closes https://github.com/ModOrganizer2/modorganizer/issues/1067.