### PR TITLE
Fix issue with QClass converter for overloaded functions.

### DIFF
--- a/src/runner/converters.h
+++ b/src/runner/converters.h
@@ -201,7 +201,6 @@ namespace utils {
     template <> struct MetaData<QFileInfo> { static const char* className() { return "QFileInfo"; } };
     template <> struct MetaData<QIcon> { static const char* className() { return "QIcon"; } };
     template <> struct MetaData<QSize> { static const char* className() { return "QSize"; } };
-    template <> struct MetaData<QStringList> { static const char* className() { return "QStringList"; } };
     template <> struct MetaData<QUrl> { static const char* className() { return "QUrl"; } };
     template <> struct MetaData<QVariant> { static const char* className() { return "QVariant"; } };
 
@@ -289,16 +288,6 @@ namespace utils {
           sipWrapper* wrapper;
           wrapper = reinterpret_cast<sipWrapper*>(objPtr);
           return wrapper->super.data;
-        }
-        else {
-          if constexpr (std::is_same_v<T, QStringList>)
-          {
-            // QStringLists aren't wrapped by PyQt - regular Python string/unicode lists are used instead
-            bpy::extract<QList<QString>> extractor(objPtr);
-            if (extractor.check()) {
-              return new QStringList(extractor());
-            }
-          }
         }
         return nullptr;
       }

--- a/src/runner/converters.h
+++ b/src/runner/converters.h
@@ -295,13 +295,12 @@ namespace utils {
           {
             // QStringLists aren't wrapped by PyQt - regular Python string/unicode lists are used instead
             bpy::extract<QList<QString>> extractor(objPtr);
-            if (extractor.check())
+            if (extractor.check()) {
               return new QStringList(extractor());
+            }
           }
-          PyErr_SetString(PyExc_TypeError, "type not wrapped");
-          bpy::throw_error_already_set();
         }
-        return new void*;
+        return 0;
       }
     };
 

--- a/src/runner/converters.h
+++ b/src/runner/converters.h
@@ -300,7 +300,7 @@ namespace utils {
             }
           }
         }
-        return 0;
+        return nullptr;
       }
     };
 

--- a/src/runner/pythonrunner.cpp
+++ b/src/runner/pythonrunner.cpp
@@ -77,7 +77,6 @@ BOOST_PYTHON_MODULE(mobase)
   utils::register_qclass_converter<QWidget>();
   utils::register_qclass_converter<QIcon>();
   utils::register_qclass_converter<QSize>();
-  utils::register_qclass_converter<QStringList>();
   utils::register_qclass_converter<QUrl>();
 
   // QFlags:
@@ -96,6 +95,7 @@ BOOST_PYTHON_MODULE(mobase)
   utils::register_sequence_container<QList<ExecutableInfo>>();
   utils::register_sequence_container<QList<PluginSetting>>();
   utils::register_sequence_container<QList<ModRepositoryFileInfo>>();
+  utils::register_sequence_container<QStringList>();
   utils::register_sequence_container<QList<QString>>();
   utils::register_sequence_container<QList<QFileInfo>>();
   utils::register_sequence_container<QList<QVariant>>(); // Required for QVariant since this is QVariantList.


### PR DESCRIPTION
Currently, `QClass_from_PyQt`  throws an exception when it does not manage to convert the `PyObject*` to a valid Qt class. This is not the right-way to do it with `boost::python` and breaks overload. 

Consider this:

```cpp
bpy::def("f1", +[](std::function<bool(QString const&)> fn) { /* ... */ });
bpy::def("f1", +[](QStringList const& fs) { /* ... */ }); 
```

And a python call:

```python
f1(lambda s: return s.endsWith(".txt"))
```

This is perfectly valid but will not work because the `QStringList` converter will be tried, and it will failed to convert the lambda to a Qt class, thus throwing the exception. If the python object is not convertible, the converter should only return a null pointer to indicate boost that the object is not convertible.