### PR TITLE
Add bindings for utility functions from uibase.

### DIFF
--- a/src/runner/pythonrunner.cpp
+++ b/src/runner/pythonrunner.cpp
@@ -801,6 +801,10 @@ BOOST_PYTHON_MODULE(mobase)
     ;
 
   registerGameFeaturesPythonConverters();
+
+  bpy::def("getFileVersion", &MOBase::getFileVersion);
+  bpy::def("getProductVersion", &MOBase::getProductVersion);
+  bpy::def("getIconForExecutable", &MOBase::iconForExecutable);
 }
 
 /**


### PR DESCRIPTION
Add python bindings for some utility functions based on the Win32 API. This is pretty useful since there is no way to do this in python and it's actually pretty useful when creating game plugins.

See https://github.com/ModOrganizer2/modorganizer-uibase/pull/59