### PR TITLE
Add bindings for IFileTree::copy().

### DIFF
--- a/src/runner/pythonrunner.cpp
+++ b/src/runner/pythonrunner.cpp
@@ -414,6 +414,13 @@ BOOST_PYTHON_MODULE(mobase)
       .def("remove", +[](IFileTree* p, std::shared_ptr<FileTreeEntry> entry) { return p->erase(entry) != p->end(); })
 
       .def("move", &IFileTree::move, bpy::arg("policy") = IFileTree::InsertPolicy::FAIL_IF_EXISTS)
+      .def("copy", +[](IFileTree* w, std::shared_ptr<const FileTreeEntry> entry, QString path, IFileTree::InsertPolicy insertPolicy) {
+        auto result = w->copy(entry, path, insertPolicy);
+        if (result == nullptr) {
+          throw std::logic_error("copy failed");
+        }
+        return result;
+      }, ((bpy::arg("path") = ""), (bpy::arg("insert_policy") = IFileTree::InsertPolicy::FAIL_IF_EXISTS)))
 
       .def("clear", &IFileTree::clear)
       .def("removeAll", &IFileTree::removeAll)


### PR DESCRIPTION
Add missing binding for `IFileTree::copy()`. Based on https://github.com/ModOrganizer2/modorganizer-uibase/pull/60/files