### PR TITLE
Fix Python -> C++ error transfer during plugin creation.

### DIFF
--- a/src/runner/pythonrunner.cpp
+++ b/src/runner/pythonrunner.cpp
@@ -1049,6 +1049,8 @@ void PythonRunner::appendIfInstance(bpy::object const& obj, QList<QObject*> &int
 
 QList<QObject*> PythonRunner::instantiate(const QString &pluginName)
 {
+  GILock lock;
+
   // `pluginName` can either be a python file (single-file plugin or a folder (whole module).
   //
   // For whole module, we simply add the parent folder to path, then we load the module with a simple 
@@ -1059,7 +1061,6 @@ QList<QObject*> PythonRunner::instantiate(const QString &pluginName)
   // from __main__ (already contains mobase, and other required module). Since the context is shared
   // between called of `instantiate`, we need to make sure to remove createPlugin(s) from previous call.
   try {
-    GILock lock;
 
     // Dictionary that will contain createPlugin() or createPlugins().
     bpy::dict moduleDict;


### PR DESCRIPTION
Similar to all the other related fixes (e712448ca0c32878ec048b475312e2097e954bf1 751e67e86c6a1bc0e77dbd4f10df6fc2b6eb134b), the `GILock` must be created outside the `try { } catch { }` otherwise it is destructed at the end of `try { }` and the error is not available anymore in `catch { }` for `throw pyexcept::PythonError();`.
