### PR TITLE
Change getLoadOrder() to return the load order in python.

### DIFF
--- a/src/runner/gamefeatureswrappers.cpp
+++ b/src/runner/gamefeatureswrappers.cpp
@@ -76,7 +76,7 @@ void GamePluginsWrapper::readPluginLists(MOBase::IPluginList * pluginList)
 
 void GamePluginsWrapper::getLoadOrder(QStringList &loadOrder)
 {
-  return basicWrapperFunctionImplementation<void>(this, "getLoadOrder", loadOrder);
+  loadOrder = basicWrapperFunctionImplementation<QStringList>(this, "getLoadOrder");
 }
 
 bool GamePluginsWrapper::lightPluginsAreSupported()
@@ -284,7 +284,11 @@ void registerGameFeaturesPythonConverters()
   bpy::class_<GamePluginsWrapper, boost::noncopyable>("GamePlugins")
       .def("writePluginLists", bpy::pure_virtual(&GamePlugins::writePluginLists))
       .def("readPluginLists", bpy::pure_virtual(&GamePlugins::readPluginLists))
-      .def("getLoadOrder", bpy::pure_virtual(&GamePlugins::getLoadOrder))
+      .def("getLoadOrder", +[](GamePlugins* p) {
+        QStringList loadOrder;
+        p->getLoadOrder(loadOrder);
+        return loadOrder;
+      })
       .def("lightPluginsAreSupported", bpy::pure_virtual(&GamePlugins::lightPluginsAreSupported))
       ;
 

--- a/src/runner/gamefeatureswrappers.cpp
+++ b/src/runner/gamefeatureswrappers.cpp
@@ -74,9 +74,9 @@ void GamePluginsWrapper::readPluginLists(MOBase::IPluginList * pluginList)
   return basicWrapperFunctionImplementation<void>(this, "readPluginLists", boost::python::ptr(pluginList));
 }
 
-void GamePluginsWrapper::getLoadOrder(QStringList &loadOrder)
+QStringList GamePluginsWrapper::getLoadOrder()
 {
-  loadOrder = basicWrapperFunctionImplementation<QStringList>(this, "getLoadOrder");
+  return basicWrapperFunctionImplementation<QStringList>(this, "getLoadOrder");
 }
 
 bool GamePluginsWrapper::lightPluginsAreSupported()
@@ -284,11 +284,7 @@ void registerGameFeaturesPythonConverters()
   bpy::class_<GamePluginsWrapper, boost::noncopyable>("GamePlugins")
       .def("writePluginLists", bpy::pure_virtual(&GamePlugins::writePluginLists))
       .def("readPluginLists", bpy::pure_virtual(&GamePlugins::readPluginLists))
-      .def("getLoadOrder", +[](GamePlugins* p) {
-        QStringList loadOrder;
-        p->getLoadOrder(loadOrder);
-        return loadOrder;
-      })
+      .def("getLoadOrder", bpy::pure_virtual(&GamePlugins::getLoadOrder))
       .def("lightPluginsAreSupported", bpy::pure_virtual(&GamePlugins::lightPluginsAreSupported))
       ;
 

--- a/src/runner/gamefeatureswrappers.h
+++ b/src/runner/gamefeatureswrappers.h
@@ -65,7 +65,7 @@ public:
 
   virtual void writePluginLists(const MOBase::IPluginList *pluginList) override;
   virtual void readPluginLists(MOBase::IPluginList *pluginList) override;
-  virtual void getLoadOrder(QStringList &loadOrder) override;
+  virtual QStringList getLoadOrder() override;
   virtual bool lightPluginsAreSupported() override;
 };
 


### PR DESCRIPTION
See https://github.com/ModOrganizer2/modorganizer-game_features/pull/14

**Note:**
- This change requires updating the existing python game plugins that have the `GamePlugins` feature (in particular the ones in https://github.com/Al12rs/modorganizer-game_generic).