### PR TITLE
Update for new organizer callbacks.

### DIFF
--- a/src/runner/pythonrunner.cpp
+++ b/src/runner/pythonrunner.cpp
@@ -75,6 +75,7 @@ BOOST_PYTHON_MODULE(mobase)
   utils::register_qclass_converter<QDir>();
   utils::register_qclass_converter<QFileInfo>();
   utils::register_qclass_converter<QWidget>();
+  utils::register_qclass_converter<QMainWindow>();
   utils::register_qclass_converter<QIcon>();
   utils::register_qclass_converter<QSize>();
   utils::register_qclass_converter<QUrl>();
@@ -130,6 +131,9 @@ BOOST_PYTHON_MODULE(mobase)
   utils::register_functor_converter<void(const QString&)>();
   utils::register_functor_converter<void(const QString&, unsigned int)>();
   utils::register_functor_converter<void(const QString&, IModList::ModStates)>(); // converter for the onModStateChanged-callback
+  utils::register_functor_converter<void(QMainWindow *)>();
+  utils::register_functor_converter<void(IProfile*, IProfile*), bpy::pointer_wrapper<IProfile*>>();
+  utils::register_functor_converter<void(QString const&, const QString& key, const QVariant&, const QVariant&)>();
   utils::register_functor_converter<bool(const IOrganizer::FileInfo&)>();
   utils::register_functor_converter<bool(const QString&)>();
   utils::register_functor_converter<bool(std::shared_ptr<FileTreeEntry> const&)>();
@@ -292,15 +296,16 @@ BOOST_PYTHON_MODULE(mobase)
           bool result = o->waitForApplication((HANDLE)handle, &returnCode);
           return std::make_tuple(result, returnCode);
         })
+      .def("refreshModList", &IOrganizer::refreshModList, (bpy::arg("save_changes") = true))
+      .def("managedGame", &IOrganizer::managedGame, bpy::return_value_policy<bpy::reference_existing_object>())
+      .def("modsSortedByProfilePriority", &IOrganizer::modsSortedByProfilePriority)
 
       .def("onModInstalled", &IOrganizer::onModInstalled)
       .def("onAboutToRun", &IOrganizer::onAboutToRun)
       .def("onFinishedRun", &IOrganizer::onFinishedRun)
-      .def("refreshModList", &IOrganizer::refreshModList, (bpy::arg("save_changes")=true))
-      .def("managedGame", &IOrganizer::managedGame, bpy::return_value_policy<bpy::reference_existing_object>())
-      .def("modsSortedByProfilePriority", &IOrganizer::modsSortedByProfilePriority)
-
-      Q_DELEGATE(IOrganizer, QObject, "_object")
+      .def("onUserInterfaceInitialized", &IOrganizer::onUserInterfaceInitialized)
+      .def("onProfileChanged", &IOrganizer::onProfileChanged)
+      .def("onPluginSettingChanged", &IOrganizer::onPluginSettingChanged)
       ;
 
   // FileTreeEntry Scope:


### PR DESCRIPTION
See https://github.com/ModOrganizer2/modorganizer-uibase/pull/61

...and that's a mess.

`boost::python` does not handle `std::function<void(IProfile*, IProfile*)>` the way I think it should. When you declare:

```cpp
bpy::def("f", +[](IProfile *, IProfile *) { });
```

...after having declared the `bpy::class_` corresponding to `IProfile`, `boost::python` has no issue handling it (it uses `IProfile*` to move back-and-forth between C++ and Python).

When you use a `std::function`, that's another issue because `boost::python` tries to perform an lvalue conversion on `IProfile`, which obviously fails since `IProfile` is abstract. The right way to fix this is by wrapper `IProfile*` in `boost::python::ptr`, but since everything is done in `Functor_converter`, I had to come up with some generic way.

The other issues is that you cannot wrap all pointers in `boost::python::ptr` and all references in `boost::ref`: types that already have registered converters should not be wrapped for instance (Qt classes, containers, tuple, variant, but also some built-in types such as `int`, etc.).

I tried excluding the type that should not be wrapped in `wrap`, but there is always an exception... So I ended-up doing the opposite: you specify what types need to be wrapped in `register_functor_converter`. For instance:

```cpp
utils::register_functor_converter<void(IProfile*, IProfile*), bpy::pointer_wrapper<IProfile*>>();
```

...says that `IProfile*` should be wrapped by `boost::python::ptr`.