### PR TITLE
Add module variable to fake MoVariant.

### DIFF
--- a/src/runner/pythonrunner.cpp
+++ b/src/runner/pythonrunner.cpp
@@ -828,7 +828,10 @@ BOOST_PYTHON_MODULE(mobase)
   bpy::def("getProductVersion", &MOBase::getProductVersion);
   bpy::def("getIconForExecutable", &MOBase::iconForExecutable);
 
-  // Expose MoVariant:
+  // Expose MoVariant: MoVariant is a fake object whose only purpose is to be used as a type-hint 
+  // on the python side (e.g., def foo(x: mobase.MoVariant)). The real MoVariant is defined in the
+  // generated stubs, since it's only relevant when doing type-checking, but this needs to be defined,
+  // otherwise MoVariant is not found when actually running plugins through MO2, making them crash.
   bpy::scope().attr("MoVariant") = bpy::object();
 }
 

--- a/src/runner/pythonrunner.cpp
+++ b/src/runner/pythonrunner.cpp
@@ -827,6 +827,9 @@ BOOST_PYTHON_MODULE(mobase)
   bpy::def("getFileVersion", &MOBase::getFileVersion);
   bpy::def("getProductVersion", &MOBase::getProductVersion);
   bpy::def("getIconForExecutable", &MOBase::iconForExecutable);
+
+  // Expose MoVariant:
+  bpy::scope().attr("MoVariant") = bpy::object();
 }
 
 /**


### PR DESCRIPTION
When passing `QVariant` from and to Python, the python interface translate values from and to python types as can be seen in https://github.com/ModOrganizer2/modorganizer-plugin_python/blob/master/src/runner/converters.h#L102 This is pretty convenient from a python point-of-view.

In order to generate meaningful stubs, I introduced `MoVariant`, a `TypeVar` defined in the stubs generated by [ModOrganizer2/pystubs-generation](https://github.com/ModOrganizer2/pystubs-generation):

```python
MoVariant = Union[None, bool, int, str, List[Any], Dict[str, Any]]
```

*Side-note: Ideally it should be `Union[None, bool, int, str, List["MoVariant"], Dict[str, "MoVariant"]]` but python type-checkers do not support recursive declaration yet (it's perfectly fine from a standard python point-of-view).*

This is pretty fine except that if you do this in your plugin:

```python
class MyPlugin(mobase.IPlugin):
    def _myFn(self, value: mobase.MoVariant): pass
```

It will fail when initialized by MO2 because `MoVariant` is not defined in `mobase`, it is only present in the stubs.

The goal of this PR is to define a fake `MoVariant` in `mobase` so that `MoVariant` can be used in python plugins for a proper type-checking using the stubs, while still being valid when actually run through MO2.

Since `MoVariant` is only meant to be used for typing, its value does not matter for proper execution, which is why it simply a default-constructed `bpy::object`, which corresponds to a `None` value in Python.