### PR TITLE
Add interfaces for IPlugin::localizedName() and IPlugin::master().

### DIFF
--- a/src/runner/gilock.cpp
+++ b/src/runner/gilock.cpp
@@ -7,5 +7,6 @@ GILock::GILock()
 
 GILock::~GILock()
 {
+  PyErr_Clear();
   PyGILState_Release(m_State);
 }

--- a/src/runner/proxypluginwrappers.cpp
+++ b/src/runner/proxypluginwrappers.cpp
@@ -40,7 +40,6 @@ QString class_name::name() const \
  \
 QString class_name::localizedName() const \
 { \
-  log::error("{}::{}", #class_name, "localizedName"); \
   return basicWrapperFunctionImplementationWithDefault<QString>(this, &class_name::localizedName_Default, "localizedName"); \
 } \
  \
@@ -73,7 +72,7 @@ QList<MOBase::PluginSetting> class_name::settings() const \
 { \
   return basicWrapperFunctionImplementation<QList<MOBase::PluginSetting>>(this, "settings"); \
 } \
-QString class_name::localizedName_Default() const { log::error("{}::{}", #class_name, "localizedName_Default"); return IPlugin::localizedName(); } \
+QString class_name::localizedName_Default() const { return IPlugin::localizedName(); } \
 IPlugin* class_name::master_Default() const { return IPlugin::master(); }
 
 /// end COMMON_I_PLUGIN_WRAPPER_DEFINITIONS

--- a/src/runner/proxypluginwrappers.cpp
+++ b/src/runner/proxypluginwrappers.cpp
@@ -38,6 +38,17 @@ QString class_name::name() const \
   return basicWrapperFunctionImplementation<QString>(this, "name"); \
 } \
  \
+QString class_name::localizedName() const \
+{ \
+  log::error("{}::{}", #class_name, "localizedName"); \
+  return basicWrapperFunctionImplementationWithDefault<QString>(this, &class_name::localizedName_Default, "localizedName"); \
+} \
+ \
+IPlugin* class_name::master() const \
+{ \
+  return basicWrapperFunctionImplementationWithDefault<IPlugin*>(this, &class_name::master_Default, "master"); \
+} \
+ \
 QString class_name::author() const \
 { \
   return basicWrapperFunctionImplementation<QString>(this, "author"); \
@@ -61,7 +72,9 @@ bool class_name::isActive() const \
 QList<MOBase::PluginSetting> class_name::settings() const \
 { \
   return basicWrapperFunctionImplementation<QList<MOBase::PluginSetting>>(this, "settings"); \
-}
+} \
+QString class_name::localizedName_Default() const { log::error("{}::{}", #class_name, "localizedName_Default"); return IPlugin::localizedName(); } \
+IPlugin* class_name::master_Default() const { return IPlugin::master(); }
 
 /// end COMMON_I_PLUGIN_WRAPPER_DEFINITIONS
 /////////////////////////////

--- a/src/runner/proxypluginwrappers.h
+++ b/src/runner/proxypluginwrappers.h
@@ -19,12 +19,15 @@
 #define COMMON_I_PLUGIN_WRAPPER_DECLARATIONS public: \
 virtual bool init(MOBase::IOrganizer *moInfo) override; \
 virtual QString name() const override; \
+virtual QString localizedName() const override; \
+virtual IPlugin* master() const override; \
 virtual QString author() const override; \
 virtual QString description() const override; \
 virtual MOBase::VersionInfo version() const override; \
 virtual bool isActive() const override; \
-virtual QList<MOBase::PluginSetting> settings() const override;
-
+virtual QList<MOBase::PluginSetting> settings() const override; \
+QString localizedName_Default() const; \
+IPlugin* master_Default() const;
 
 // Even though the base interface is not a QObject, this has to be because we have no way to pass Mod Organizer a plugin that implements multiple interfaces.
 // QObject must be the first base class because moc assumes the first base class is a QObject

--- a/src/runner/pythonrunner.cpp
+++ b/src/runner/pythonrunner.cpp
@@ -672,9 +672,14 @@ BOOST_PYTHON_MODULE(mobase)
       .def("onModMoved", &MOBase::IModList::onModMoved, bpy::arg("callback"))
       ;
 
+  // Note: localizedName() and master() have to go in all the plugin wrappers declaration,
+  // since the default functions are specific to each wrapper, otherwise in turns into an
+  // infinite recursion mess.
   bpy::class_<IPluginWrapper, boost::noncopyable>("IPlugin")
     .def("init", bpy::pure_virtual(&MOBase::IPlugin::init), bpy::arg("organizer"))
     .def("name", bpy::pure_virtual(&MOBase::IPlugin::name))
+    .def("localizedName", &MOBase::IPlugin::localizedName, &IPluginWrapper::localizedName_Default)
+    .def("master", &MOBase::IPlugin::master, &IPluginWrapper::master_Default, bpy::return_value_policy<bpy::reference_existing_object>())
     .def("author", bpy::pure_virtual(&MOBase::IPlugin::author))
     .def("description", bpy::pure_virtual(&MOBase::IPlugin::description))
     .def("version", bpy::pure_virtual(&MOBase::IPlugin::version))
@@ -683,6 +688,9 @@ BOOST_PYTHON_MODULE(mobase)
     ;
 
   bpy::class_<IPluginDiagnoseWrapper, bpy::bases<IPlugin>, boost::noncopyable>("IPluginDiagnose")
+      .def("localizedName", &MOBase::IPlugin::localizedName, &IPluginDiagnoseWrapper::localizedName_Default)
+      .def("master", &MOBase::IPlugin::master, &IPluginDiagnoseWrapper::master_Default, bpy::return_value_policy<bpy::reference_existing_object>())
+
       .def("activeProblems", bpy::pure_virtual(&MOBase::IPluginDiagnose::activeProblems))
       .def("shortDescription", bpy::pure_virtual(&MOBase::IPluginDiagnose::shortDescription), bpy::arg("key"))
       .def("fullDescription", bpy::pure_virtual(&MOBase::IPluginDiagnose::fullDescription), bpy::arg("key"))
@@ -699,6 +707,8 @@ BOOST_PYTHON_MODULE(mobase)
       ;
 
   bpy::class_<IPluginFileMapperWrapper, bpy::bases<IPlugin>, boost::noncopyable>("IPluginFileMapper")
+      .def("localizedName", &MOBase::IPlugin::localizedName, &IPluginFileMapperWrapper::localizedName_Default)
+      .def("master", &MOBase::IPlugin::master, &IPluginFileMapperWrapper::master_Default, bpy::return_value_policy<bpy::reference_existing_object>())
       .def("mappings", bpy::pure_virtual(&MOBase::IPluginFileMapper::mappings))
       ;
 
@@ -731,6 +741,9 @@ BOOST_PYTHON_MODULE(mobase)
       ;
 
   bpy::class_<IPluginGameWrapper, bpy::bases<IPlugin>, boost::noncopyable>("IPluginGame")
+      .def("localizedName", &MOBase::IPlugin::localizedName, &IPluginGameWrapper::localizedName_Default)
+      .def("master", &MOBase::IPlugin::master, &IPluginGameWrapper::master_Default, bpy::return_value_policy<bpy::reference_existing_object>())
+
       .def("gameName", bpy::pure_virtual(&MOBase::IPluginGame::gameName))
       .def("initializeProfile", bpy::pure_virtual(&MOBase::IPluginGame::initializeProfile), (bpy::arg("directory"), "settings"))
       .def("savegameExtension", bpy::pure_virtual(&MOBase::IPluginGame::savegameExtension))
@@ -821,6 +834,9 @@ BOOST_PYTHON_MODULE(mobase)
     ;
 
   bpy::class_<IPluginInstallerSimpleWrapper, bpy::bases<IPluginInstaller>, boost::noncopyable>("IPluginInstallerSimple")
+    .def("localizedName", &MOBase::IPlugin::localizedName, &IPluginInstallerSimpleWrapper::localizedName_Default)
+    .def("master", &MOBase::IPlugin::master, &IPluginInstallerSimpleWrapper::master_Default, bpy::return_value_policy<bpy::reference_existing_object>())
+
     // Note: Keeping the variant here even if we always return a tuple to be consistent with the wrapper and
     // have proper stubs generation.
     .def("install", +[](IPluginInstallerSimple* p, GuessedValue<QString>& modName, std::shared_ptr<IFileTree>& tree, QString& version, int& nexusID)
@@ -833,6 +849,9 @@ BOOST_PYTHON_MODULE(mobase)
     ;
 
   bpy::class_<IPluginInstallerCustomWrapper, bpy::bases<IPluginInstaller>, boost::noncopyable>("IPluginInstallerCustom")
+    .def("localizedName", &MOBase::IPlugin::localizedName, &IPluginInstallerCustomWrapper::localizedName_Default)
+    .def("master", &MOBase::IPlugin::master, &IPluginInstallerCustomWrapper::master_Default, bpy::return_value_policy<bpy::reference_existing_object>())
+
     // Needs to add both otherwize boost does not understand:    
     .def("isArchiveSupported", &IPluginInstaller::isArchiveSupported, bpy::arg("tree"))
     .def("isArchiveSupported", &IPluginInstallerCustom::isArchiveSupported, bpy::arg("archive_name"))
@@ -843,6 +862,9 @@ BOOST_PYTHON_MODULE(mobase)
     ;
 
   bpy::class_<IPluginModPageWrapper, bpy::bases<IPlugin>, boost::noncopyable>("IPluginModPage")
+    .def("localizedName", &MOBase::IPlugin::localizedName, &IPluginModPageWrapper::localizedName_Default)
+    .def("master", &MOBase::IPlugin::master, &IPluginModPageWrapper::master_Default, bpy::return_value_policy<bpy::reference_existing_object>())
+
     .def("displayName", bpy::pure_virtual(&IPluginModPage::displayName))
     .def("icon", bpy::pure_virtual(&IPluginModPage::icon))
     .def("pageURL", bpy::pure_virtual(&IPluginModPage::pageURL))
@@ -853,12 +875,18 @@ BOOST_PYTHON_MODULE(mobase)
     ;
 
   bpy::class_<IPluginPreviewWrapper, bpy::bases<IPlugin>, boost::noncopyable>("IPluginPreview")
+    .def("localizedName", &MOBase::IPlugin::localizedName, &IPluginPreviewWrapper::localizedName_Default)
+    .def("master", &MOBase::IPlugin::master, &IPluginPreviewWrapper::master_Default, bpy::return_value_policy<bpy::reference_existing_object>())
+
     .def("supportedExtensions", bpy::pure_virtual(&IPluginPreview::supportedExtensions))
     .def("genFilePreview", bpy::pure_virtual(&IPluginPreview::genFilePreview), bpy::return_value_policy<bpy::return_by_value>(), 
       (bpy::arg("filename"), "max_size"))
     ;
 
   bpy::class_<IPluginToolWrapper, bpy::bases<IPlugin>, boost::noncopyable>("IPluginTool")
+    .def("localizedName", &MOBase::IPlugin::localizedName, &IPluginToolWrapper::localizedName_Default)
+    .def("master", &MOBase::IPlugin::master, &IPluginToolWrapper::master_Default, bpy::return_value_policy<bpy::reference_existing_object>())
+
     .def("displayName", bpy::pure_virtual(&IPluginTool::displayName))
     .def("tooltip", bpy::pure_virtual(&IPluginTool::tooltip))
     .def("icon", bpy::pure_virtual(&IPluginTool::icon))


### PR DESCRIPTION
**TL;DR;** Adds bindings for `IPlugin::localizedName()` and `IPlugin::master()`.

This may looks like a lots of change to add two small bindings but I spent 4 hours trying to get this working... Basically, these two methods have default behavior, that must be specified at some point, but since the `IPlugin` custom codes are in macro, then it is not possible to only have them in the top-level `bpy::class_<IPluginWrapper, ...>` but we need them in each sub-class.

I also add to clear exception from Python since `localizedName()` recurses into `name()`, so `name()` would fail due to an error from `get_override()`, which is why I now have two `GILock`. I had to use a lambda here because `bpy::override` does not have a default constructor, and I did not want to modify `GILock` to allow for "unlock" or something like that.