### PR TITLE
Fix implicit conversion from non-const IFileTree to const IFileTree.

### DIFF
--- a/src/runner/pythonrunner.cpp
+++ b/src/runner/pythonrunner.cpp
@@ -87,8 +87,10 @@ BOOST_PYTHON_MODULE(mobase)
   // Pointers:
   bpy::register_ptr_to_python<std::shared_ptr<FileTreeEntry>>();
   bpy::register_ptr_to_python<std::shared_ptr<const FileTreeEntry>>();
+  bpy::implicitly_convertible<std::shared_ptr<FileTreeEntry>, std::shared_ptr<const FileTreeEntry>>();
   bpy::register_ptr_to_python<std::shared_ptr<IFileTree>>();
   bpy::register_ptr_to_python<std::shared_ptr<const IFileTree>>();
+  bpy::implicitly_convertible<std::shared_ptr<IFileTree>, std::shared_ptr<const IFileTree>>();
 
   // Containers:
   utils::register_sequence_container<std::vector<int>>();


### PR DESCRIPTION
In C++ there is an implicit conversion from `std::shared_ptr<X>` to `std::shared_ptr<const X>`. This is not the case with `boost::python`, so this causes some issues (e.g. you cannot pass the file tree from `IPluginInstallerSimple::install()` to `ModDataChecker::dataLooksValid()`).

This fixes it by registering implicit conversion for `std::shared_ptr<IFileTree>` to `std::shared_ptr<const IFileTree>`.