### PR TITLE
Add handler for Python logging module.

### DIFF
--- a/src/runner/pylogger.cpp
+++ b/src/runner/pylogger.cpp
@@ -43,7 +43,7 @@ void emit_function(bpy::object self, bpy::object record) {
   }
 };
 
-void configure_python_logging()
+bpy::object configure_python_logging()
 {
   // Most of this is dealing with actual Python objects since it is not possible
   // to derive from logging.Handler in C++ using Boost.Python, and since a lot of
@@ -59,11 +59,13 @@ void configure_python_logging()
   // Create the "MO2Handler" python class:
   auto methods = bpy::dict();
   methods["emit"] = bpy::make_function(emit_function);
-  auto MO2Handler = bpy::call<bpy::object>(type, "MO2Handler", bpy::make_tuple(handler), methods);
+  auto MO2Handler = bpy::call<bpy::object>(type, "LogHandler", bpy::make_tuple(handler), methods);
 
   // Call basicConfig() with a new instance of our handler.
   auto kwargs = bpy::dict();
   kwargs["handlers"] = bpy::make_tuple(MO2Handler());
   kwargs["level"] = 0;
   logging.attr("basicConfig")(*bpy::make_tuple(), **kwargs);
+
+  return MO2Handler;
 }

--- a/src/runner/pylogger.cpp
+++ b/src/runner/pylogger.cpp
@@ -1,0 +1,69 @@
+#include "pylogger.h"
+
+#include "log.h"
+
+#include <boost/python.hpp>
+
+namespace bpy = boost::python;
+
+// Small structure to hold the levels - There are copy paste from
+// my Python version and I assume these will not change soon:
+struct PyLogLevel {
+  static constexpr int CRITICAL = 50;
+  static constexpr int ERROR = 40;
+  static constexpr int WARNING = 30;
+  static constexpr int INFO = 20;
+  static constexpr int DEBUG = 10;
+};
+
+// This is the function we are going to use as our Handler .emit
+// method.
+void emit_function(bpy::object self, bpy::object record) {
+
+  // There are other parameters that could be used, but this is minimal for
+  // now (filename, line number, etc.).
+  const int level = bpy::extract<int>(record.attr("levelno"));
+  const std::wstring msg = bpy::extract<std::wstring>(record.attr("msg"));
+
+  switch (level) {
+  case PyLogLevel::CRITICAL:
+  case PyLogLevel::ERROR:
+    MOBase::log::error("{}", msg);
+    break;
+  case PyLogLevel::WARNING:
+    MOBase::log::warn("{}", msg);
+    break;
+  case PyLogLevel::INFO:
+    MOBase::log::info("{}", msg);
+    break;
+  case PyLogLevel::DEBUG:
+  default: // There is a "NOTSET" level in theory:
+    MOBase::log::debug("{}", msg);
+    break;
+  }
+};
+
+void configure_python_logging()
+{
+  // Most of this is dealing with actual Python objects since it is not possible
+  // to derive from logging.Handler in C++ using Boost.Python, and since a lot of
+  // this would require extra register only for this.
+
+  // Retrieve the logging module and the Handler class.
+  auto logging = bpy::import("logging");
+  auto handler = logging.attr("Handler");
+
+  // This is ugly but that's how it's done in C Python.
+  auto type = (PyObject*)&PyType_Type;
+
+  // Create the "MO2Handler" python class:
+  auto methods = bpy::dict();
+  methods["emit"] = bpy::make_function(emit_function);
+  auto MO2Handler = bpy::call<bpy::object>(type, "MO2Handler", bpy::make_tuple(handler), methods);
+
+  // Call basicConfig() with a new instance of our handler.
+  auto kwargs = bpy::dict();
+  kwargs["handlers"] = bpy::make_tuple(MO2Handler());
+  kwargs["level"] = 0;
+  logging.attr("basicConfig")(*bpy::make_tuple(), **kwargs);
+}

--- a/src/runner/pylogger.cpp
+++ b/src/runner/pylogger.cpp
@@ -23,7 +23,7 @@ void emit_function(bpy::object self, bpy::object record) {
   // There are other parameters that could be used, but this is minimal for
   // now (filename, line number, etc.).
   const int level = bpy::extract<int>(record.attr("levelno"));
-  const std::wstring msg = bpy::extract<std::wstring>(record.attr("msg"));
+  const std::wstring msg = bpy::extract<std::wstring>(bpy::str(record.attr("msg")));
 
   switch (level) {
   case PyLogLevel::CRITICAL:

--- a/src/runner/pylogger.h
+++ b/src/runner/pylogger.h
@@ -6,8 +6,8 @@
 /**
  * @brief Configure logging for MO2 python plugin.
  *
- * @return the log handler class.
+ * @param mobase The mobase module.
  */
-boost::python::object configure_python_logging();
+void configure_python_logging(boost::python::object mobase);
 
 #endif

--- a/src/runner/pylogger.h
+++ b/src/runner/pylogger.h
@@ -1,10 +1,13 @@
 #ifndef MO2_PYTHON_LOGGER_H
 #define MO2_PYTHON_LOGGER_H
 
+#include <boost/python.hpp>
+
 /**
  * @brief Configure logging for MO2 python plugin.
  *
+ * @return the log handler class.
  */
-void configure_python_logging();
+boost::python::object configure_python_logging();
 
 #endif

--- a/src/runner/pylogger.h
+++ b/src/runner/pylogger.h
@@ -1,0 +1,10 @@
+#ifndef MO2_PYTHON_LOGGER_H
+#define MO2_PYTHON_LOGGER_H
+
+/**
+ * @brief Configure logging for MO2 python plugin.
+ *
+ */
+void configure_python_logging();
+
+#endif

--- a/src/runner/pythonrunner.cpp
+++ b/src/runner/pythonrunner.cpp
@@ -39,6 +39,7 @@
 #include "tuple_helper.h"
 #include "variant_helper.h"
 #include "converters.h"
+#include "pylogger.h"
 
 using namespace MOBase;
 
@@ -1195,6 +1196,8 @@ bool PythonRunner::initPython(const QString &pythonPath)
               "sys.stderr = moprivate.ErrWrapper.instance()\n"
               "sys.excepthook = lambda x, y, z: sys.__excepthook__(x, y, z)\n",
                         mainNamespace);
+
+    configure_python_logging();
 
     PyEval_SaveThread();
     return true;

--- a/src/runner/pythonrunner.cpp
+++ b/src/runner/pythonrunner.cpp
@@ -1197,7 +1197,7 @@ bool PythonRunner::initPython(const QString &pythonPath)
               "sys.excepthook = lambda x, y, z: sys.__excepthook__(x, y, z)\n",
                         mainNamespace);
 
-    configure_python_logging();
+    mainNamespace["mobase"].attr("LogHandler") = configure_python_logging();
 
     PyEval_SaveThread();
     return true;

--- a/src/runner/pythonrunner.cpp
+++ b/src/runner/pythonrunner.cpp
@@ -1197,7 +1197,7 @@ bool PythonRunner::initPython(const QString &pythonPath)
               "sys.excepthook = lambda x, y, z: sys.__excepthook__(x, y, z)\n",
                         mainNamespace);
 
-    mainNamespace["mobase"].attr("LogHandler") = configure_python_logging();
+    configure_python_logging(mainNamespace["mobase"]);
 
     PyEval_SaveThread();
     return true;


### PR DESCRIPTION
Currently, the only way to log stuff in Python is to use `print(...)` and `print(..., file=sys.stderr)`. This does not expose the granularity available in MO2 and has a few drawbacks (e.g. logging to `sys.stderr` always print a spurious `error.cpp`).

This PR provides a logger from the built-in `logging` module in `mobase` that uses `MOBase::log`, so that the following would do appropriate things:

```python
import mobase

mobase.logger.debug("Debug")
mobase.logger.info("Info")
mobase.logger.warning("Warning")
mobase.logger.error("Error")
```

The log level on `mobase.logger` and the associated handleris set to 10 (info) since it's the MO2 log module that filters messages.

It's also possible to create other loggers, e.g. if plugin want to enable/disable logging for specific part of the plugin:

```python
import logging
import mobase

logger = logging.getLogger("MyLogger")
logger.addHandler(mobase.LogHandler(level=logging.INFO))
logger.setLevel(logging.INFO)
```