### PR TITLE
Fix deletion of shared_ptr created from C++.

### DIFF
--- a/src/runner/gamefeatureswrappers.cpp
+++ b/src/runner/gamefeatureswrappers.cpp
@@ -9,6 +9,7 @@
 #include <isavegame.h>
 #include <isavegameinfowidget.h>
 
+#include "shared_ptr_converter.h"
 #include "ifiletree.h"
 #include "pythonwrapperutilities.h"
 
@@ -108,7 +109,9 @@ ModDataChecker::CheckReturn ModDataCheckerWrapper::dataLooksValid(std::shared_pt
 }
 
 std::shared_ptr<MOBase::IFileTree> ModDataCheckerWrapper::fix(std::shared_ptr<MOBase::IFileTree> fileTree) const {
-  return basicWrapperFunctionImplementationWithDefault<std::shared_ptr<MOBase::IFileTree>>(this, [](auto&&... args) { return nullptr; }, "fix", fileTree);
+  return utils::clean_shared_ptr(
+    basicWrapperFunctionImplementationWithDefault<std::shared_ptr<MOBase::IFileTree>>(
+      this, [](auto&&... args) { return nullptr; }, "fix", fileTree));
 }
 
 /// end ModDataChecker Wrapper


### PR DESCRIPTION
Closes ModOrganizer2/modorganizer#1445

Related to Python 3.8.7. It's possible that this is a bug in Boost.Python but I don't really know... It's not the cleanest fix but it's the only one I can come up with.