### PR TITLE
Import mobase after installing the exception wrapper.

### DIFF
--- a/src/runner/pythonrunner.cpp
+++ b/src/runner/pythonrunner.cpp
@@ -1328,13 +1328,14 @@ bool PythonRunner::initPython(const QString &pythonPath)
     bpy::object mainNamespace = mainModule.attr("__dict__");
     mainNamespace["sys"] = bpy::import("sys");
     mainNamespace["moprivate"] = bpy::import("moprivate");
-    mainNamespace["mobase"] = bpy::import("mobase");
     bpy::import("site");
     bpy::exec("sys.stdout = moprivate.PrintWrapper()\n"
               "sys.stderr = moprivate.ErrWrapper.instance()\n"
               "sys.excepthook = lambda x, y, z: sys.__excepthook__(x, y, z)\n",
                         mainNamespace);
 
+
+    mainNamespace["mobase"] = bpy::import("mobase");
     configure_python_logging(mainNamespace["mobase"]);
 
     PyEval_SaveThread();


### PR DESCRIPTION
Closes ModOrganizer2/modorganizer#1451

This loads `mobase` after putting the exception wrapper in place. This should fix most cryptic error messages (some may remain but I don't think there is a way to put the exception wrapper in place earlier).