### PR TITLE
Plugin sorting updates

### DIFF
--- a/src/mobase/wrappers/pyplugins.cpp
+++ b/src/mobase/wrappers/pyplugins.cpp
@@ -76,6 +76,7 @@ namespace mo2::python {
             .def("executableForcedLoads", &IPluginGame::executableForcedLoads)
             .def("steamAPPId", &IPluginGame::steamAPPId)
             .def("primaryPlugins", &IPluginGame::primaryPlugins)
+            .def("enabledPlugins", &IPluginGame::enabledPlugins)
             .def("gameVariants", &IPluginGame::gameVariants)
             .def("setGameVariant", &IPluginGame::setGameVariant, "variant"_a)
             .def("binaryName", &IPluginGame::binaryName)

--- a/src/mobase/wrappers/pyplugins.h
+++ b/src/mobase/wrappers/pyplugins.h
@@ -416,6 +416,10 @@ namespace mo2::python {
         {
             PYBIND11_OVERRIDE_PURE(QStringList, IPluginGame, primaryPlugins, );
         }
+        QStringList enabledPlugins() const override
+        {
+            PYBIND11_OVERRIDE_PURE(QStringList, IPluginGame, enabledPlugins, );
+        }
         QStringList gameVariants() const override
         {
             PYBIND11_OVERRIDE_PURE(QStringList, IPluginGame, gameVariants, );


### PR DESCRIPTION
- Add enabledPlugins for core plugins which are enabled but NOT auto-loaded (may need to be written to plugins.txt or have an ambiguous load order position)
- General Starfield updates
  - Add enabledPlugins for "BlueprintShips-Starfield.esm"
  - Disable plugin management if sTestFile is in use (also applies to FO4)
  - Write the enabledPlugins to plugins.txt to enforce base game load order
  - Allow for LOOT sorting (dynamic based on settings)
- Incorporate enabledPlugins into force enabled plugins in plugin list
- Update various interface layers

TODO: Fix sort button to dynamically update if status changes
TODO: Auto refresh lists if the INI Editor is closed