### PR TITLE
Oblivion Remastered Support

### DIFF
--- a/src/mobase/wrappers/pyplugins.cpp
+++ b/src/mobase/wrappers/pyplugins.cpp
@@ -55,6 +55,7 @@ namespace mo2::python {
             .def("gameIcon", &IPluginGame::gameIcon)
             .def("gameDirectory", &IPluginGame::gameDirectory)
             .def("dataDirectory", &IPluginGame::dataDirectory)
+            .def("modDataDirectory", &IPluginGame::modDataDirectory)
             .def("secondaryDataDirectories", &IPluginGame::secondaryDataDirectories)
             .def("setGamePath", &IPluginGame::setGamePath, "path"_a)
             .def("documentsDirectory", &IPluginGame::documentsDirectory)
@@ -82,7 +83,8 @@ namespace mo2::python {
             .def("looksValid", &IPluginGame::looksValid, "directory"_a)
             .def("gameVersion", &IPluginGame::gameVersion)
             .def("getLauncherName", &IPluginGame::getLauncherName)
-            .def("getSupportURL", &IPluginGame::getSupportURL);
+            .def("getSupportURL", &IPluginGame::getSupportURL)
+            .def("getModMappings", &IPluginGame::getModMappings);
     }
 
     // multiple installers

--- a/src/mobase/wrappers/pyplugins.h
+++ b/src/mobase/wrappers/pyplugins.h
@@ -397,6 +397,10 @@ namespace mo2::python {
         {
             PYBIND11_OVERRIDE_PURE(QDir, IPluginGame, dataDirectory, );
         }
+        QString modDataDirectory() const override
+        {
+            PYBIND11_OVERRIDE(QString, IPluginGame, modDataDirectory, );
+        }
         QMap<QString, QDir> secondaryDataDirectories() const override
         {
             using string_dir_map = QMap<QString, QDir>;
@@ -510,6 +514,11 @@ namespace mo2::python {
         QString getSupportURL() const override
         {
             PYBIND11_OVERRIDE(QString, IPluginGame, getSupportURL, );
+        }
+        QMap<QString, QStringList> getModMappings() const override
+        {
+            using vfs_map = QMap<QString, QStringList>;
+            PYBIND11_OVERRIDE(vfs_map, IPluginGame, getModMappings, );
         }
     };
 


### PR DESCRIPTION
Adding interfaces for VFS mod mapping updates (used to get Oblivion Remastered to map to multiple locations).

* modDataDirectory defines mod directory that maps to 'Data'
  - This is used to tell the main interface where to look for 'Data' files and defaults to the root directory
* getModMappings allows mapping directories to multiple locations
  - This contains mod subdirectory -> VFS directory mappings (where the VFS mappings can be a list of locations)
  - By default, will map the root mod directory to the game 'data' directory (and any secondary data directories if defined)
  - Oblivion Releloaded maps 'Data' to the game `Data`, 'Paks' to the game `Paks\~mods`, 'OBSE' to the root `OBSE` directory and so on.